### PR TITLE
fix: Temporary fix for GCC12 compile issue of Presstimo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,7 +383,8 @@ if(ENABLE_ALL_WARNINGS)
          -Wno-maybe-uninitialized \
          -Wno-unused-result \
          -Wno-format-overflow \
-         -Wno-strict-aliasing")
+         -Wno-strict-aliasing \
+	 -Wno-error=restrict")
   endif()
 
   set(KNOWN_WARNINGS


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Add a compile flag to exempt a specific error.
```
In file included from /opt/rh/gcc-toolset-12/root/usr/include/c++/12/ios:40,
                 from /opt/rh/gcc-toolset-12/root/usr/include/c++/12/ostream:38,
                 from /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/unique_ptr.h:41,
                 from /opt/rh/gcc-toolset-12/root/usr/include/c++/12/memory:76,
                 from /usr/local/include/folly/Function.h:205,
                 from /usr/local/include/folly/CancellationToken.h:20,
                 from /__w/presto/presto/presto-native-execution/velox/velox/connectors/Connector.h:18,
                 from /__w/presto/presto/presto-native-execution/velox/velox/connectors/clp/ClpColumnHandle.h:19,
                 from /__w/presto/presto/presto-native-execution/velox/velox/connectors/clp/ClpDataSource.cpp:19:
In static member function 'static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)',
    inlined from 'static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/basic_string.h:423:21,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/basic_string.tcc:532:22,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/basic_string.h:1647:19,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/basic_string.h:815:28,
    inlined from 'facebook::velox::connector::clp::ClpDataSource::ClpDataSource(const facebook::velox::RowTypePtr&, const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>&, const std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<facebook::velox::connector::ColumnHandle> >&, facebook::velox::memory::MemoryPool*, std::shared_ptr<const facebook::velox::connector::clp::ClpConfig>&)' at /__w/presto/presto/presto-native-execution/velox/velox/connectors/clp/ClpDataSource.cpp:43:17:
/opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/char_traits.h:431:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Pass the ci.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler settings to suppress certain warning messages during builds when all warnings are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->