### PR TITLE
feat: Allow KQL query to be modified during splits retrieval.

### DIFF
--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -21,14 +21,23 @@
 namespace facebook::velox::connector::clp {
 
 struct ClpConnectorSplit : public connector::ConnectorSplit {
-  ClpConnectorSplit(const std::string& connectorId, const std::string& path)
-      : connector::ConnectorSplit(connectorId), path_(path) {}
+  ClpConnectorSplit(
+      const std::string& connectorId,
+      const std::string& path,
+      std::shared_ptr<std::string> kqlQuery)
+      : connector::ConnectorSplit(connectorId),
+        path_(path),
+        kqlQuery_(kqlQuery) {}
 
   [[nodiscard]] std::string toString() const override {
-    return fmt::format("CLP Split: {}", path_);
+    return fmt::format(
+        "CLP Split: path: {}, kqlQuery: {}",
+        path_,
+        kqlQuery_ ? *kqlQuery_ : "<null>");
   }
 
   const std::string path_;
+  std::shared_ptr<std::string> kqlQuery_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpDataSource.h
+++ b/velox/connectors/clp/ClpDataSource.h
@@ -92,7 +92,6 @@ class ClpDataSource : public DataSource {
       size_t& readerIndex);
 
   ClpConfig::StorageType storageType_;
-  std::string kqlQuery_;
   velox::memory::MemoryPool* pool_;
   RowTypePtr outputType_;
   std::set<std::string> columnUntypedNames_;

--- a/velox/connectors/clp/ClpTableHandle.h
+++ b/velox/connectors/clp/ClpTableHandle.h
@@ -22,20 +22,11 @@ namespace facebook::velox::connector::clp {
 
 class ClpTableHandle : public ConnectorTableHandle {
  public:
-  ClpTableHandle(
-      const std::string& connectorId,
-      const std::string& tableName,
-      std::shared_ptr<std::string> kqlQuery)
-      : ConnectorTableHandle(connectorId),
-        tableName_(tableName),
-        kqlQuery_(std::move(kqlQuery)) {}
+  ClpTableHandle(const std::string& connectorId, const std::string& tableName)
+      : ConnectorTableHandle(connectorId), tableName_(tableName) {}
 
   [[nodiscard]] const std::string& tableName() const {
     return tableName_;
-  }
-
-  [[nodiscard]] const std::shared_ptr<std::string>& kqlQuery() const {
-    return kqlQuery_;
   }
 
   std::string toString() const override;
@@ -44,7 +35,6 @@ class ClpTableHandle : public ConnectorTableHandle {
 
  private:
   const std::string tableName_;
-  std::shared_ptr<std::string> kqlQuery_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -95,7 +95,7 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
                       ROW({"requestId", "userId", "method"},
                           {VARCHAR(), VARCHAR(), VARCHAR()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_1", kqlQuery))
+                      kClpConnectorId, "test_1"))
                   .assignments({
                       {"requestId",
                        std::make_shared<ClpColumnHandle>(
@@ -140,7 +140,7 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
                       ROW({"requestId", "userId", "path"},
                           {VARCHAR(), VARCHAR(), VARCHAR()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_1", kqlQuery))
+                      kClpConnectorId, "test_1"))
                   .assignments({
                       {"requestId",
                        std::make_shared<ClpColumnHandle>(
@@ -177,8 +177,8 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
                   {TIMESTAMP(),
                    ROW({"type", "subtype", "severity"},
                        {VARCHAR(), VARCHAR(), VARCHAR()})}))
-          .tableHandle(std::make_shared<ClpTableHandle>(
-              kClpConnectorId, "test_2", kqlQuery))
+          .tableHandle(
+              std::make_shared<ClpTableHandle>(kClpConnectorId, "test_2"))
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
@@ -228,7 +228,7 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
                            ROW({"type", "subtype", "severity"},
                                {VARCHAR(), VARCHAR(), VARCHAR()})}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_2", kqlQuery))
+                      kClpConnectorId, "test_2"))
                   .assignments(
                       {{"timestamp",
                         std::make_shared<ClpColumnHandle>(
@@ -273,8 +273,8 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
                   {TIMESTAMP(),
                    ROW({"type", "subtype", "severity", "tags"},
                        {VARCHAR(), VARCHAR(), VARCHAR(), ARRAY(VARCHAR())})}))
-          .tableHandle(std::make_shared<ClpTableHandle>(
-              kClpConnectorId, "test_2", kqlQuery))
+          .tableHandle(
+              std::make_shared<ClpTableHandle>(kClpConnectorId, "test_2"))
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
@@ -317,7 +317,7 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
                   .startTableScan()
                   .outputType(ROW({"timestamp"}, {TIMESTAMP()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_3", kqlQuery))
+                      kClpConnectorId, "test_3"))
                   .assignments(
                       {{"timestamp",
                         std::make_shared<ClpColumnHandle>(

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -66,9 +66,11 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  exec::Split makeClpSplit(const std::string& splitPath) {
-    return exec::Split(
-        std::make_shared<ClpConnectorSplit>(kClpConnectorId, splitPath));
+  exec::Split makeClpSplit(
+      const std::string& splitPath,
+      std::shared_ptr<std::string> kqlQuery) {
+    return exec::Split(std::make_shared<ClpConnectorSplit>(
+        kClpConnectorId, splitPath, kqlQuery));
   }
 
   RowVectorPtr getResults(
@@ -86,13 +88,14 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
 };
 
 TEST_F(ClpConnectorTest, test1NoPushdown) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
   auto plan = PlanBuilder()
                   .startTableScan()
                   .outputType(
                       ROW({"requestId", "userId", "method"},
                           {VARCHAR(), VARCHAR(), VARCHAR()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_1", nullptr))
+                      kClpConnectorId, "test_1", kqlQuery))
                   .assignments({
                       {"requestId",
                        std::make_shared<ClpColumnHandle>(
@@ -108,8 +111,8 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
                   .filter("method = 'GET'")
                   .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_1.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_1.clps"), kqlQuery)});
   auto expected = makeRowVector(
       {// requestId
        makeFlatVector<StringView>(
@@ -129,16 +132,15 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
 }
 
 TEST_F(ClpConnectorTest, test1Pushdown) {
+  const std::shared_ptr<std::string> kqlQuery =
+      std::make_shared<std::string>("method: \"POST\" AND status: 200");
   auto plan = PlanBuilder()
                   .startTableScan()
                   .outputType(
                       ROW({"requestId", "userId", "path"},
                           {VARCHAR(), VARCHAR(), VARCHAR()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId,
-                      "test_1",
-                      std::make_shared<std::string>(
-                          "method: \"POST\" AND status: 200")))
+                      kClpConnectorId, "test_1", kqlQuery))
                   .assignments({
                       {"requestId",
                        std::make_shared<ClpColumnHandle>(
@@ -153,8 +155,8 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
                   .endTableScan()
                   .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_1.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_1.clps"), kqlQuery)});
   auto expected =
       makeRowVector({// requestId
                      makeFlatVector<StringView>({"req-106"}),
@@ -166,6 +168,7 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
 }
 
 TEST_F(ClpConnectorTest, test2NoPushdown) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
   auto plan =
       PlanBuilder(pool_.get())
           .startTableScan()
@@ -175,7 +178,7 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
                    ROW({"type", "subtype", "severity"},
                        {VARCHAR(), VARCHAR(), VARCHAR()})}))
           .tableHandle(std::make_shared<ClpTableHandle>(
-              kClpConnectorId, "test_2", nullptr))
+              kClpConnectorId, "test_2", kqlQuery))
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
@@ -194,8 +197,8 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
               "(event.type = 'storage' AND event.subtype LIKE 'disk_usage%'))")
           .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_2.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -213,37 +216,35 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
 }
 
 TEST_F(ClpConnectorTest, test2Pushdown) {
-  auto plan =
-      PlanBuilder()
-          .startTableScan()
-          .outputType(
-              ROW({"timestamp", "event"},
-                  {TIMESTAMP(),
-                   ROW({"type", "subtype", "severity"},
-                       {VARCHAR(), VARCHAR(), VARCHAR()})}))
-          .tableHandle(std::make_shared<ClpTableHandle>(
-              kClpConnectorId,
-              "test_2",
-              std::make_shared<std::string>(
-                  "(event.severity: \"WARNING\" OR event.severity: \"ERROR\") AND "
-                  "((event.type: \"network\" AND event.subtype: \"connection\") OR "
-                  "(event.type: \"storage\" AND event.subtype: \"disk*\"))")))
-          .assignments(
-              {{"timestamp",
-                std::make_shared<ClpColumnHandle>(
-                    "timestamp", "timestamp", TIMESTAMP(), true)},
-               {"event",
-                std::make_shared<ClpColumnHandle>(
-                    "event",
-                    "event",
-                    ROW({"type", "subtype", "severity"},
-                        {VARCHAR(), VARCHAR(), VARCHAR()}),
-                    true)}})
-          .endTableScan()
-          .planNode();
+  const std::shared_ptr<std::string> kqlQuery = std::make_shared<std::string>(
+      "(event.severity: \"WARNING\" OR event.severity: \"ERROR\") AND "
+      "((event.type: \"network\" AND event.subtype: \"connection\") OR "
+      "(event.type: \"storage\" AND event.subtype: \"disk*\"))");
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(
+                      ROW({"timestamp", "event"},
+                          {TIMESTAMP(),
+                           ROW({"type", "subtype", "severity"},
+                               {VARCHAR(), VARCHAR(), VARCHAR()})}))
+                  .tableHandle(std::make_shared<ClpTableHandle>(
+                      kClpConnectorId, "test_2", kqlQuery))
+                  .assignments(
+                      {{"timestamp",
+                        std::make_shared<ClpColumnHandle>(
+                            "timestamp", "timestamp", TIMESTAMP(), true)},
+                       {"event",
+                        std::make_shared<ClpColumnHandle>(
+                            "event",
+                            "event",
+                            ROW({"type", "subtype", "severity"},
+                                {VARCHAR(), VARCHAR(), VARCHAR()}),
+                            true)}})
+                  .endTableScan()
+                  .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_2.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -261,6 +262,9 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
 }
 
 TEST_F(ClpConnectorTest, test2Hybrid) {
+  const std::shared_ptr<std::string> kqlQuery = std::make_shared<std::string>(
+      "((event.type: \"network\" AND event.subtype: \"connection\") OR "
+      "(event.type: \"storage\" AND event.subtype: \"disk*\"))");
   auto plan =
       PlanBuilder(pool_.get())
           .startTableScan()
@@ -270,11 +274,7 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
                    ROW({"type", "subtype", "severity", "tags"},
                        {VARCHAR(), VARCHAR(), VARCHAR(), ARRAY(VARCHAR())})}))
           .tableHandle(std::make_shared<ClpTableHandle>(
-              kClpConnectorId,
-              "test_2",
-              std::make_shared<std::string>(
-                  "((event.type: \"network\" AND event.subtype: \"connection\") OR "
-                  "(event.type: \"storage\" AND event.subtype: \"disk*\"))")))
+              kClpConnectorId, "test_2", kqlQuery))
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
@@ -290,8 +290,8 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
           .filter("upper(event.severity) IN ('WARNING', 'ERROR')")
           .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_2.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
   auto expected = makeRowVector(
       {// timestamp
        makeFlatVector<Timestamp>(
@@ -312,11 +312,12 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
 }
 
 TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
   auto plan = PlanBuilder(pool_.get())
                   .startTableScan()
                   .outputType(ROW({"timestamp"}, {TIMESTAMP()}))
                   .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_3", nullptr))
+                      kClpConnectorId, "test_3", kqlQuery))
                   .assignments(
                       {{"timestamp",
                         std::make_shared<ClpColumnHandle>(
@@ -324,8 +325,8 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
                   .endTableScan()
                   .planNode();
 
-  auto output =
-      getResults(plan, {makeClpSplit(getExampleFilePath("test_3.clps"))});
+  auto output = getResults(
+      plan, {makeClpSplit(getExampleFilePath("test_3.clps"), kqlQuery)});
   auto expected = makeRowVector({
       // timestamp
       makeFlatVector<Timestamp>(

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -132,7 +132,7 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
 }
 
 TEST_F(ClpConnectorTest, test1Pushdown) {
-  const std::shared_ptr<std::string> kqlQuery =
+  auto kqlQuery =
       std::make_shared<std::string>("method: \"POST\" AND status: 200");
   auto plan = PlanBuilder()
                   .startTableScan()
@@ -216,7 +216,7 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
 }
 
 TEST_F(ClpConnectorTest, test2Pushdown) {
-  const std::shared_ptr<std::string> kqlQuery = std::make_shared<std::string>(
+  auto kqlQuery = std::make_shared<std::string>(
       "(event.severity: \"WARNING\" OR event.severity: \"ERROR\") AND "
       "((event.type: \"network\" AND event.subtype: \"connection\") OR "
       "(event.type: \"storage\" AND event.subtype: \"disk*\"))");
@@ -262,7 +262,7 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
 }
 
 TEST_F(ClpConnectorTest, test2Hybrid) {
-  const std::shared_ptr<std::string> kqlQuery = std::make_shared<std::string>(
+  auto kqlQuery = std::make_shared<std::string>(
       "((event.type: \"network\" AND event.subtype: \"connection\") OR "
       "(event.type: \"storage\" AND event.subtype: \"disk*\"))");
   auto plan =


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to allow the KQL query can be modified after the coordinator lists the splits. There also could be possibilities that the splits have their own KQL query respectively. So we need to provide the functionality that the KQL query can be updated after listing splits, and store the KQL query per split to cover the case that splits have different KQL queries.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

When doing E2E testing, put the break point at `ClpDataSource.cpp:L112` and check if the `pushDownQuery` can get the correct push down passed from the coordinator (or none if there is no push-down-able KQL query). Also check the `clpSplit-toString()` can get the correct text.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for per-split query execution, allowing each split to specify its own query.

* **Refactor**
  * Updated the handling of query parameters to improve flexibility and remove redundant storage.
  * Simplified table handle constructor by removing query parameter and related accessors.

* **Tests**
  * Improved test coverage by adding support for optional query strings in split creation and updated test cases accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->