### PR TITLE
refactor: Remove the unnecessary `nullable` from `ClpColumnHandle`.

### DIFF
--- a/velox/connectors/clp/ClpColumnHandle.h
+++ b/velox/connectors/clp/ClpColumnHandle.h
@@ -25,12 +25,10 @@ class ClpColumnHandle : public ColumnHandle {
   ClpColumnHandle(
       const std::string& columnName,
       const std::string& originalColumnName,
-      const TypePtr& columnType,
-      bool nullable)
+      const TypePtr& columnType)
       : columnName_(columnName),
         originalColumnName_(originalColumnName),
-        columnType_(columnType),
-        nullable_(nullable) {}
+        columnType_(columnType) {}
 
   const std::string& columnName() const {
     return columnName_;
@@ -44,15 +42,10 @@ class ClpColumnHandle : public ColumnHandle {
     return columnType_;
   }
 
-  bool nullable() const {
-    return nullable_;
-  }
-
  private:
   const std::string columnName_;
   const std::string originalColumnName_;
   const TypePtr columnType_;
-  const bool nullable_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -99,13 +99,13 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
                   .assignments({
                       {"requestId",
                        std::make_shared<ClpColumnHandle>(
-                           "requestId", "requestId", VARCHAR(), true)},
+                           "requestId", "requestId", VARCHAR())},
                       {"userId",
                        std::make_shared<ClpColumnHandle>(
-                           "userId", "userId", VARCHAR(), true)},
+                           "userId", "userId", VARCHAR())},
                       {"method",
                        std::make_shared<ClpColumnHandle>(
-                           "method", "method", VARCHAR(), true)},
+                           "method", "method", VARCHAR())},
                   })
                   .endTableScan()
                   .filter("method = 'GET'")
@@ -134,26 +134,26 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
 TEST_F(ClpConnectorTest, test1Pushdown) {
   auto kqlQuery =
       std::make_shared<std::string>("method: \"POST\" AND status: 200");
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .outputType(
-                      ROW({"requestId", "userId", "path"},
-                          {VARCHAR(), VARCHAR(), VARCHAR()}))
-                  .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_1"))
-                  .assignments({
-                      {"requestId",
-                       std::make_shared<ClpColumnHandle>(
-                           "requestId", "requestId", VARCHAR(), true)},
-                      {"userId",
-                       std::make_shared<ClpColumnHandle>(
-                           "userId", "userId", VARCHAR(), true)},
-                      {"path",
-                       std::make_shared<ClpColumnHandle>(
-                           "path", "path", VARCHAR(), true)},
-                  })
-                  .endTableScan()
-                  .planNode();
+  auto plan =
+      PlanBuilder()
+          .startTableScan()
+          .outputType(
+              ROW({"requestId", "userId", "path"},
+                  {VARCHAR(), VARCHAR(), VARCHAR()}))
+          .tableHandle(
+              std::make_shared<ClpTableHandle>(kClpConnectorId, "test_1"))
+          .assignments({
+              {"requestId",
+               std::make_shared<ClpColumnHandle>(
+                   "requestId", "requestId", VARCHAR())},
+              {"userId",
+               std::make_shared<ClpColumnHandle>(
+                   "userId", "userId", VARCHAR())},
+              {"path",
+               std::make_shared<ClpColumnHandle>("path", "path", VARCHAR())},
+          })
+          .endTableScan()
+          .planNode();
 
   auto output = getResults(
       plan, {makeClpSplit(getExampleFilePath("test_1.clps"), kqlQuery)});
@@ -182,14 +182,13 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
-                    "timestamp", "timestamp", TIMESTAMP(), true)},
+                    "timestamp", "timestamp", TIMESTAMP())},
                {"event",
                 std::make_shared<ClpColumnHandle>(
                     "event",
                     "event",
                     ROW({"type", "subtype", "severity"},
-                        {VARCHAR(), VARCHAR(), VARCHAR()}),
-                    true)}})
+                        {VARCHAR(), VARCHAR(), VARCHAR()}))}})
           .endTableScan()
           .filter(
               "event.severity IN ('WARNING', 'ERROR') AND "
@@ -232,14 +231,13 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
                   .assignments(
                       {{"timestamp",
                         std::make_shared<ClpColumnHandle>(
-                            "timestamp", "timestamp", TIMESTAMP(), true)},
+                            "timestamp", "timestamp", TIMESTAMP())},
                        {"event",
                         std::make_shared<ClpColumnHandle>(
                             "event",
                             "event",
                             ROW({"type", "subtype", "severity"},
-                                {VARCHAR(), VARCHAR(), VARCHAR()}),
-                            true)}})
+                                {VARCHAR(), VARCHAR(), VARCHAR()}))}})
                   .endTableScan()
                   .planNode();
 
@@ -278,14 +276,13 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
           .assignments(
               {{"timestamp",
                 std::make_shared<ClpColumnHandle>(
-                    "timestamp", "timestamp", TIMESTAMP(), true)},
+                    "timestamp", "timestamp", TIMESTAMP())},
                {"event",
                 std::make_shared<ClpColumnHandle>(
                     "event",
                     "event",
                     ROW({"type", "subtype", "severity", "tags"},
-                        {VARCHAR(), VARCHAR(), VARCHAR(), ARRAY(VARCHAR())}),
-                    true)}})
+                        {VARCHAR(), VARCHAR(), VARCHAR(), ARRAY(VARCHAR())}))}})
           .endTableScan()
           .filter("upper(event.severity) IN ('WARNING', 'ERROR')")
           .planNode();
@@ -321,7 +318,7 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
                   .assignments(
                       {{"timestamp",
                         std::make_shared<ClpColumnHandle>(
-                            "timestamp", "timestamp", TIMESTAMP(), true)}})
+                            "timestamp", "timestamp", TIMESTAMP())}})
                   .endTableScan()
                   .planNode();
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
As discussed in https://github.com/y-scope/presto/pull/45, `nullable` is always `true` for the CLP connector column handles, and it's not actually used in Velox. This PR removes this redundant field.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Passed the CI.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified column handling by removing the nullable attribute from column definitions and related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->