### PR TITLE
feat: Update CLP submodule to remove unnecessary `clp_s::archive_writer` from `clp-s-search` lib.

### DIFF
--- a/CMake/resolve_dependency_modules/clp.cmake
+++ b/CMake/resolve_dependency_modules/clp.cmake
@@ -16,7 +16,7 @@ include_guard(GLOBAL)
 FetchContent_Declare(
   clp
   GIT_REPOSITORY https://github.com/y-scope/clp.git
-  GIT_TAG 0798100389bd5231b520ec48ab186275795e3790)
+  GIT_TAG 0bfaf5caec80d17527a2e91ba21fdede88b44f19)
 
 set(CLP_BUILD_CLP_REGEX_UTILS
     OFF

--- a/velox/connectors/clp/search_lib/CMakeLists.txt
+++ b/velox/connectors/clp/search_lib/CMakeLists.txt
@@ -25,7 +25,6 @@ velox_link_libraries(
   clp-s-search
   PUBLIC clp_s::archive_reader
   PRIVATE
-    clp_s::archive_writer
     clp_s::clp_dependencies
     clp_s::io
     clp_s::search


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
`clp_s::search` was not correctly linked, so we had to add `clp_s::archive_writer` to make the build work. https://github.com/y-scope/clp/pull/1066 resolved this issue, and we can update clp commit hash and remove `clp_s::archive_writer` from the target list.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
