### PR TITLE
feat: Add split type to `ClpSplit` to prepare to support searching CLP IR files.

### DIFF
--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -24,26 +24,26 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   ClpConnectorSplit(
       const std::string& connectorId,
       const std::string& path,
-      std::shared_ptr<std::string> kqlQuery,
-      const int type)
+      const int type,
+      std::shared_ptr<std::string> kqlQuery)
       : connector::ConnectorSplit(connectorId),
         path_(path),
-        kqlQuery_(std::move(kqlQuery)),
-        type_(static_cast<SplitType>(type)) {}
+        type_(static_cast<SplitType>(type)),
+        kqlQuery_(std::move(kqlQuery)) {}
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
-        "CLP Split: path: {}, kqlQuery: {}, type: {}",
+        "CLP Split: path: {}, type: {}, kqlQuery: {}",
         path_,
-        kqlQuery_ ? *kqlQuery_ : "<null>",
-        type_ == SplitType::kArchive ? "Archive" : "IR");
+        type_ == SplitType::kArchive ? "Archive" : "Ir",
+        kqlQuery_ ? *kqlQuery_ : "<null>");
   }
 
-  enum class SplitType : int { kArchive, kIR };
+  enum class SplitType : int { kArchive, kIr };
 
   const std::string path_;
-  std::shared_ptr<std::string> kqlQuery_;
   const SplitType type_;
+  std::shared_ptr<std::string> kqlQuery_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -24,10 +24,12 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   ClpConnectorSplit(
       const std::string& connectorId,
       const std::string& path,
-      std::shared_ptr<std::string> kqlQuery)
+      std::shared_ptr<std::string> kqlQuery,
+      const int type)
       : connector::ConnectorSplit(connectorId),
         path_(path),
-        kqlQuery_(kqlQuery) {}
+        kqlQuery_(std::move(kqlQuery)),
+        type_(static_cast<Type>(type)) {}
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
@@ -36,8 +38,11 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
         kqlQuery_ ? *kqlQuery_ : "<null>");
   }
 
+  enum class Type : int { kArchive, kIR };
+
   const std::string path_;
   std::shared_ptr<std::string> kqlQuery_;
+  const Type type_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -29,21 +29,21 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
       : connector::ConnectorSplit(connectorId),
         path_(path),
         kqlQuery_(std::move(kqlQuery)),
-        type_(static_cast<Type>(type)) {}
+        type_(static_cast<SplitType>(type)) {}
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
         "CLP Split: path: {}, kqlQuery: {}, type: {}",
         path_,
         kqlQuery_ ? *kqlQuery_ : "<null>",
-        type_ == Type::kArchive ? "Archive" : "IR");
+        type_ == SplitType::kArchive ? "Archive" : "IR");
   }
 
-  enum class Type : int { kArchive, kIR };
+  enum class SplitType : int { kArchive, kIR };
 
   const std::string path_;
   std::shared_ptr<std::string> kqlQuery_;
-  const Type type_;
+  const SplitType type_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -33,9 +33,10 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
-        "CLP Split: path: {}, kqlQuery: {}",
+        "CLP Split: path: {}, kqlQuery: {}, type: {}",
         path_,
-        kqlQuery_ ? *kqlQuery_ : "<null>");
+        kqlQuery_ ? *kqlQuery_ : "<null>",
+        type_ == Type::kArchive ? "Archive" : "IR");
   }
 
   enum class Type : int { kArchive, kIR };

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -68,9 +68,10 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
 
   exec::Split makeClpSplit(
       const std::string& splitPath,
-      std::shared_ptr<std::string> kqlQuery) {
+      std::shared_ptr<std::string> kqlQuery,
+      ClpConnectorSplit::Type type) {
     return exec::Split(std::make_shared<ClpConnectorSplit>(
-        kClpConnectorId, splitPath, kqlQuery));
+        kClpConnectorId, splitPath, kqlQuery, static_cast<int>(type)));
   }
 
   RowVectorPtr getResults(
@@ -112,7 +113,11 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
                   .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_1.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_1.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected = makeRowVector(
       {// requestId
        makeFlatVector<StringView>(
@@ -156,7 +161,11 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
           .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_1.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_1.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected =
       makeRowVector({// requestId
                      makeFlatVector<StringView>({"req-106"}),
@@ -197,7 +206,11 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
           .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_2.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -242,7 +255,11 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
                   .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_2.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -288,7 +305,11 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
           .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_2.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_2.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected = makeRowVector(
       {// timestamp
        makeFlatVector<Timestamp>(
@@ -323,7 +344,11 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
                   .planNode();
 
   auto output = getResults(
-      plan, {makeClpSplit(getExampleFilePath("test_3.clps"), kqlQuery)});
+      plan,
+      {makeClpSplit(
+          getExampleFilePath("test_3.clps"),
+          kqlQuery,
+          ClpConnectorSplit::Type::kArchive)});
   auto expected = makeRowVector({
       // timestamp
       makeFlatVector<Timestamp>(

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -69,7 +69,7 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
   exec::Split makeClpSplit(
       const std::string& splitPath,
       std::shared_ptr<std::string> kqlQuery,
-      ClpConnectorSplit::Type type) {
+      ClpConnectorSplit::SplitType type) {
     return exec::Split(std::make_shared<ClpConnectorSplit>(
         kClpConnectorId, splitPath, kqlQuery, static_cast<int>(type)));
   }
@@ -117,7 +117,7 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
       {makeClpSplit(
           getExampleFilePath("test_1.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected = makeRowVector(
       {// requestId
        makeFlatVector<StringView>(
@@ -165,7 +165,7 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
       {makeClpSplit(
           getExampleFilePath("test_1.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected =
       makeRowVector({// requestId
                      makeFlatVector<StringView>({"req-106"}),
@@ -210,7 +210,7 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -259,7 +259,7 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -309,7 +309,7 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected = makeRowVector(
       {// timestamp
        makeFlatVector<Timestamp>(
@@ -348,7 +348,7 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
       {makeClpSplit(
           getExampleFilePath("test_3.clps"),
           kqlQuery,
-          ClpConnectorSplit::Type::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive)});
   auto expected = makeRowVector({
       // timestamp
       makeFlatVector<Timestamp>(

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -68,10 +68,10 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
 
   exec::Split makeClpSplit(
       const std::string& splitPath,
-      std::shared_ptr<std::string> kqlQuery,
-      ClpConnectorSplit::SplitType type) {
+      ClpConnectorSplit::SplitType type,
+      std::shared_ptr<std::string> kqlQuery) {
     return exec::Split(std::make_shared<ClpConnectorSplit>(
-        kClpConnectorId, splitPath, kqlQuery, static_cast<int>(type)));
+        kClpConnectorId, splitPath, static_cast<int>(type), kqlQuery));
   }
 
   RowVectorPtr getResults(
@@ -116,8 +116,8 @@ TEST_F(ClpConnectorTest, test1NoPushdown) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_1.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected = makeRowVector(
       {// requestId
        makeFlatVector<StringView>(
@@ -164,8 +164,8 @@ TEST_F(ClpConnectorTest, test1Pushdown) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_1.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected =
       makeRowVector({// requestId
                      makeFlatVector<StringView>({"req-106"}),
@@ -209,8 +209,8 @@ TEST_F(ClpConnectorTest, test2NoPushdown) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -258,8 +258,8 @@ TEST_F(ClpConnectorTest, test2Pushdown) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected =
       makeRowVector({// timestamp
                      makeFlatVector<Timestamp>({Timestamp(
@@ -308,8 +308,8 @@ TEST_F(ClpConnectorTest, test2Hybrid) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_2.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected = makeRowVector(
       {// timestamp
        makeFlatVector<Timestamp>(
@@ -347,8 +347,8 @@ TEST_F(ClpConnectorTest, test3TimestampMarshalling) {
       plan,
       {makeClpSplit(
           getExampleFilePath("test_3.clps"),
-          kqlQuery,
-          ClpConnectorSplit::SplitType::kArchive)});
+          ClpConnectorSplit::SplitType::kArchive,
+          kqlQuery)});
   auto expected = makeRowVector({
       // timestamp
       makeFlatVector<Timestamp>(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

We added `type` property stored in the `ClpSplit` and nested enum class `SplitType` (We cannot name it `Type` because it will conflict with `ColumnHandle`'s `Type` because there is no way to config this remapping in protocol's YAML according to the [doc](https://github.com/y-scope/presto/blob/release-0.293-clp-connector/presto-native-execution/presto_cpp/presto_protocol/README.md#presto_protocolyml)). This property is to discern whether the dataset we want to conduct search is IR files or archives. We can refer to this [commit](https://github.com/y-scope/velox/pull/4/commits/7c0f91eca5946c60935e7f5976e01f150838cee8).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Set a breakpoint at `ClpDataSource.cpp:addSplit()` to check if the type was passed and parsed correctly.
<img width="1491" height="977" alt="image" src="https://github.com/user-attachments/assets/ed6a234a-d950-4d65-87a4-e058de25a655" />

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying split types with distinct categories for improved clarity.

* **Other Changes**
  * Enhanced display of split type information for better user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->