### PR TITLE
feat: Add support for duplicate columns in Projection.

### DIFF
--- a/velox/connectors/clp/search_lib/ClpCursor.cpp
+++ b/velox/connectors/clp/search_lib/ClpCursor.cpp
@@ -181,7 +181,7 @@ ErrorCode ClpCursor::loadArchive() {
   }
 
   projection_ = std::make_shared<Projection>(
-      outputColumns_.empty() ? ReturnAllColumns : ReturnSelectedColumns);
+      outputColumns_.empty() ? ReturnAllColumns : ReturnSelectedColumns, true);
   try {
     for (auto const& column : outputColumns_) {
       std::vector<std::string> descriptorTokens;


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds support for duplicate columns in projections. This is useful when accessing the same nested field through both a UDF and a row type because they may produce two identical fields.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Updated internal projection handling to align with a new constructor interface, with no changes to user workflows or behaviour.
- Chores
  - Maintenance update to ensure compatibility with underlying components, preserving existing functionality and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->