### PR TITLE
fix(docs): Fix `ClpS3AuthProviderBase` anchor.

### DIFF
--- a/velox/docs/develop/connectors.rst
+++ b/velox/docs/develop/connectors.rst
@@ -151,7 +151,7 @@ and simplified into an AST. On ``next``, the cursor finds matching row indices a
 ``ClpDataSource`` recursively creates a row vector composed of lazy vectors, which use CLP column readers to
 decode and load data as needed during execution.
 
-.. _ClpS3AuthProviderBase
+.. _ClpS3AuthProviderBase:
 
 ClpS3AuthProviderBase
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixed the anchor syntax in the `velox/docs/develop/connectors.rst`. This was induced from https://github.com/y-scope/velox/pull/21, however the CI didn't catch this as an error so the CI still passed.

I just created an issue related to the CI problem here: https://github.com/y-scope/velox/issues/34

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

End-to-end setup http server and checkout the page on browser.
Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Corrected a reference anchor formatting issue in the connectors documentation to ensure cross-references render correctly in published docs.
  * Improves documentation navigation and link stability; users may notice more reliable intra-page and section links when browsing the connectors content.
  * No content, behaviour, configuration, or compatibility changes. No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->