### PR TITLE
fix: Infer input source for IR files to match behaviour with archive search.

### DIFF
--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -87,7 +87,7 @@ ErrorCode ClpIrCursor::loadSplit() {
   }
   auto queryHandler = std::move(queryHandlerResult).value();
 
-  auto irPath = Path{.source = inputSource_, .path = splitPath_};
+  auto irPath = get_path_object_for_raw_path(splitPath_);
   irReader_ = try_create_reader(irPath, networkAuthOption);
   if (nullptr == irReader_) {
     VLOG(2) << "Failed to create IR reader";


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Currently, when reading IR files from an unauthenticated HTTP path, the input source is incorrectly set to the local file system with `AuthMethod` as `None`. In reality, it should be treated as a network source.

This PR fixes the issue by using `get_path_object_for_raw_path` to obtain the correct path object instead of constructing it manually.

This is a temporary fix to make the behavior consistent with archives. As mentioned in #41, we should eventually introduce a dedicated configuration option for handling unauthenticated HTTP input sources.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal path resolution mechanism for search operations to improve consistency when handling different input source types during search reader initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->