### PR TITLE
fix: Remove log-surgeon test build dependency causing Catch2 errors

### DIFF
--- a/CMake/resolve_dependency_modules/log_surgeon.cmake
+++ b/CMake/resolve_dependency_modules/log_surgeon.cmake
@@ -19,6 +19,7 @@ FetchContent_Declare(
   GIT_TAG 85d4f2c09c0e55f1fb87cdc8b0f4d13fb1a733e1
   OVERRIDE_FIND_PACKAGE)
 
+set(log_surgeon_BUILD_TESTING OFF)
 FetchContent_MakeAvailable(log_surgeon)
 
 # To work around y-scope/log-surgeon#155


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Currently, the Velox CMake configuration builds log-surgeon's testing dependencies during setup, which causes unresolved Catch2 dependencies. This PR disables log-surgeon testing since it is not needed in the Velox repository.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update contains internal build configuration adjustments to optimize the dependency build process.

* **Chores**
  * Updated build configuration for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->