### PR TITLE
ci: Migrate from stateful to stateless runner and apply optimizations to reduce workflow runtime:

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           # Use Clang compiler if requested (e.g., scheduled.yml uses Clang for compiler diversity)
           # Otherwise defaults to GCC (default CC/CXX in the container)
-          if [[ "${USE_CLANG}" = "true" ]]; then
+          if [ "${USE_CLANG}" = "true" ]; then
             export CC=/usr/bin/clang-15
             export CXX=/usr/bin/clang++-15
           fi
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          if [[ -n "${{ matrix.ulimit-nofile }}" ]]; then
+          if [ -n "${{ matrix.ulimit-nofile }}" ]; then
             ulimit -n ${{ matrix.ulimit-nofile }}
           fi
           cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -43,7 +43,7 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.test-group }})
     needs: builder-image
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_owner == 'y-scope' && fromJSON('["self-hosted", "x64", "ubuntu-noble"]') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -67,7 +67,7 @@ jobs:
       # Set `CCACHE_BASEDIR` so cache keys use relative paths
       CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -33,23 +33,29 @@ jobs:
       contents: read
       packages: write
 
-  # Second job: run the slow velox_exec_test in parallel with other-tests
-  # This job and other-tests run in parallel after builder-image completes
-  velox-exec-test:
-    # velox_exec_test takes 15+ minutes to run (981 seconds observed), which is significantly
-    # longer than all other tests combined. Running it separately allows other tests to complete
-    # quickly while this long-running test executes in parallel.
-    #
-    # To separate additional slow tests in the future:
-    # 1. Create a new job similar to this one with -R "test_name" to run only that test
-    # 2. Update the other-tests job to exclude it using -E "test_name_1|test_name_2|..."
-    #    (use pipe | to exclude multiple tests with regex pattern)
-    name: Build and Test Velox (velox_exec_test)
+  # Build and test jobs run in parallel after builder-image completes.
+  # velox_exec_test takes 15+ minutes (significantly longer than all other tests combined),
+  # so we run it separately to allow other tests to complete quickly in parallel.
+  #
+  # To separate additional slow tests in the future:
+  # 1. Add a new matrix entry with ctest-args: '-R "test_name"'
+  # 2. Update the "other" entry to exclude it: '-E "velox_exec_test|test_name"'
+  build-and-test:
+    name: Build and Test (${{ matrix.test-group }})
     needs: builder-image
     runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-group: velox_exec_test
+            ctest-args: -R velox_exec_test
+          - test-group: other
+            ctest-args: -E velox_exec_test
+            # Increase file descriptor limit for velox_table_evolution_fuzzer_test
+            ulimit-nofile: 8192
     container:
       # Image tag is dynamically generated based on dependency hash (intentionally unpinned)
-      # Gets the image from builder-image job output (e.g., ghcr.io/y-scope/velox/...:a1b2c3d4e5f6)
       image: ${{ needs.builder-image.outputs.image-tag }}
     env:
       USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
@@ -71,75 +77,25 @@ jobs:
           # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)
           # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
           # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
-          # Self-hosted runners have more cores/RAM, so can handle higher parallelism
           MAKEFLAGS: >-
             MAX_HIGH_MEM_JOBS=${{ contains(runner.labels, 'self-hosted') && '16' || '4' }}
             MAX_LINK_JOBS=${{ contains(runner.labels, 'self-hosted') && '12' || '3' }}
         run: |
           # Use Clang compiler if requested (e.g., scheduled.yml uses Clang for compiler diversity)
           # Otherwise defaults to GCC (default CC/CXX in the container)
-          if [[ "${USE_CLANG}" = "true" ]]; then export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; fi
+          if [[ "${USE_CLANG}" = "true" ]]; then
+            export CC=/usr/bin/clang-15
+            export CXX=/usr/bin/clang++-15
+          fi
           make release
 
       - name: Show CCache Stats After Build
-        run: |
-          ccache -vs
+        run: ccache -vs
 
-      - name: Run velox_exec_test
+      - name: Run Tests
         run: |
-          # Run only velox_exec_test which takes ~16 minutes
-          # -R: Run tests matching regex pattern (only velox_exec_test)
-          # -j: Parallel execution using all available CPUs
+          if [[ -n "${{ matrix.ulimit-nofile }}" ]]; then
+            ulimit -n ${{ matrix.ulimit-nofile }}
+          fi
           cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \
-            -R "velox_exec_test"
-
-  # Third job: run all other tests (excluding velox_exec_test) in parallel with velox-exec-test
-  other-tests:
-    name: Build and Test Velox (other tests)
-    needs: builder-image
-    runs-on: self-hosted
-    container:
-      # Image tag is dynamically generated based on dependency hash (intentionally unpinned)
-      # Gets the same image as velox-exec-test job (both run in parallel using same image)
-      image: ${{ needs.builder-image.outputs.image-tag }}
-    env:
-      USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
-      # Set CCACHE_BASEDIR to checkout path so cache keys use relative paths
-      CCACHE_BASEDIR: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Clear CCache Statistics
-        run: |
-          # Clear ccache statistics (not the cache itself) so final stats reflect only this build
-          # The actual cached compilation results from the warmup build are preserved
-          ccache -z
-
-      - name: Build Velox
-        env:
-          # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)
-          # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
-          # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
-          MAKEFLAGS: >-
-            MAX_HIGH_MEM_JOBS=${{ contains(runner.labels, 'self-hosted') && '16' || '4' }}
-            MAX_LINK_JOBS=${{ contains(runner.labels, 'self-hosted') && '12' || '3' }}
-        run: |
-          if [[ "${USE_CLANG}" = "true" ]]; then export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; fi
-          make release
-
-      - name: Show CCache Stats After Build
-        run: |
-          ccache -vs
-
-      - name: Run Other Tests (excluding velox_exec_test)
-        run: |
-          # Increase file descriptor limit to prevent "Too many open files" errors
-          # Required by velox_table_evolution_fuzzer_test which opens many files concurrently
-          ulimit -n 8192
-          # Run all tests except velox_exec_test which takes 16+ minutes and runs in parallel
-          # -E: Exclude tests matching regex pattern (velox_exec_test runs in separate job)
-          # -j: Parallel execution using all available CPUs
-          cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \
-            -E "velox_exec_test"
+            ${{ matrix.ctest-args }}

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -53,6 +53,8 @@ jobs:
       image: ${{ needs.builder-image.outputs.image-tag }}
     env:
       USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
+      # Set CCACHE_BASEDIR to checkout path so cache keys use relative paths
+      CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,6 +104,8 @@ jobs:
       image: ${{ needs.builder-image.outputs.image-tag }}
     env:
       USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
+      # Set CCACHE_BASEDIR to checkout path so cache keys use relative paths
+      CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -66,12 +66,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Clear CCache Statistics
-        run: |
-          # Clear ccache statistics (not the cache itself) so final stats reflect only this build
-          # The actual cached compilation results from the warmup build are preserved
-          ccache -z
-
       - name: Build Velox
         env:
           # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -24,8 +24,6 @@ on:
         type: boolean
 
 jobs:
-  # First job: build or retrieve the Docker builder image
-  # This image contains all dependencies and pre-populated ccache for fast builds
   builder-image:
     name: Build builder image
     uses: ./.github/workflows/yscope-velox-builder-img.yml
@@ -33,15 +31,16 @@ jobs:
       contents: read
       packages: write
 
-  # Build and test jobs run in parallel after builder-image completes.
-  # velox_exec_test takes 15+ minutes (significantly longer than all other tests combined),
+  # Build and run tests after `builder-image` completes.
+  #
+  # NOTE: `velox_exec_test` takes 15+ minutes (significantly longer than all other tests combined),
   # so we run it separately to allow other tests to complete quickly in parallel.
   #
   # To separate additional slow tests in the future:
   # 1. Add a new matrix entry with ctest-args: '-R "test_name"'
   # 2. Update the "other" entry to exclude it: '-E "velox_exec_test|test_name"'
   build-and-test:
-    name: Build and Test (${{ matrix.test-group }})
+    name: Build and test (${{ matrix.test-group }})
     needs: builder-image
     runs-on: >-
       ${{
@@ -57,14 +56,15 @@ jobs:
             ctest-args: -R velox_exec_test
           - test-group: other
             ctest-args: -E velox_exec_test
-            # Increase file descriptor limit for velox_table_evolution_fuzzer_test
+
+            # Increase file descriptor limit for `velox_table_evolution_fuzzer_test`
             ulimit-nofile: 8192
     container:
-      # Image tag is dynamically generated based on dependency hash (intentionally unpinned)
-      image: ${{ needs.builder-image.outputs.image-tag }}
+      image: ${{ needs.builder-image.outputs.image-ref }}
     env:
       USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
-      # Set CCACHE_BASEDIR to checkout path so cache keys use relative paths
+
+      # Set `CCACHE_BASEDIR` so cache keys use relative paths
       CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
@@ -73,22 +73,20 @@ jobs:
 
       - name: Build Velox
         env:
-          # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)
+          # Tune parallelism based on runner type: Self-hosted (16-core) vs GitHub-hosted (4-core)
           # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
           # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
           MAKEFLAGS: >-
             MAX_HIGH_MEM_JOBS=${{ runner.environment == 'self-hosted' && '16' || '4' }}
             MAX_LINK_JOBS=${{ runner.environment == 'self-hosted' && '12' || '3' }}
         run: |
-          # Use Clang compiler if requested (e.g., scheduled.yml uses Clang for compiler diversity)
-          # Otherwise defaults to GCC (default CC/CXX in the container)
           if [ "${USE_CLANG}" = "true" ]; then
             export CC=/usr/bin/clang-15
             export CXX=/usr/bin/clang++-15
           fi
           make release
 
-      - name: Show CCache Stats After Build
+      - name: Show CCache stats after build
         run: ccache -vs
 
       - name: Run Tests
@@ -96,5 +94,9 @@ jobs:
           if [ -n "${{ matrix.ulimit-nofile }}" ]; then
             ulimit -n ${{ matrix.ulimit-nofile }}
           fi
-          cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \
-            ${{ matrix.ctest-args }}
+          cd _build/release \
+            && ctest \
+              -j $(getconf _NPROCESSORS_ONLN) \
+              --output-on-failure \
+              --no-tests=error \
+              ${{ matrix.ctest-args }}

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -43,7 +43,12 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.test-group }})
     needs: builder-image
-    runs-on: ${{ github.repository_owner == 'y-scope' && fromJSON('["self-hosted", "x64", "ubuntu-noble"]') || 'ubuntu-latest' }}
+    runs-on: >-
+        ${{
+            github.repository_owner == 'y-scope'
+            && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+            || 'ubuntu-latest'
+        }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -67,7 +67,7 @@ jobs:
       # Set `CCACHE_BASEDIR` so cache keys use relative paths
       CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -44,11 +44,11 @@ jobs:
     name: Build and Test (${{ matrix.test-group }})
     needs: builder-image
     runs-on: >-
-        ${{
-            github.repository_owner == 'y-scope'
-            && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
-            || 'ubuntu-latest'
-        }}
+      ${{
+          github.repository_owner == 'y-scope'
+          && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+          || 'ubuntu-latest'
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -72,8 +72,8 @@ jobs:
           # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
           # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
           MAKEFLAGS: >-
-            MAX_HIGH_MEM_JOBS=${{ contains(runner.labels, 'self-hosted') && '16' || '4' }}
-            MAX_LINK_JOBS=${{ contains(runner.labels, 'self-hosted') && '12' || '3' }}
+            MAX_HIGH_MEM_JOBS=${{ runner.environment == 'self-hosted' && '16' || '4' }}
+            MAX_LINK_JOBS=${{ runner.environment == 'self-hosted' && '12' || '3' }}
         run: |
           # Use Clang compiler if requested (e.g., scheduled.yml uses Clang for compiler diversity)
           # Otherwise defaults to GCC (default CC/CXX in the container)

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -24,45 +24,118 @@ on:
         type: boolean
 
 jobs:
-  ubuntu-release:
-    name: Ubuntu release with resolve_dependency
-    runs-on: yscope-gh-runner
+  # First job: build or retrieve the Docker builder image
+  # This image contains all dependencies and pre-populated ccache for fast builds
+  builder-image:
+    name: Build builder image
+    uses: ./.github/workflows/yscope-velox-builder-img.yml
+    permissions:
+      contents: read
+      packages: write
+
+  # Second job: run the slow velox_exec_test in parallel with other-tests
+  # This job and other-tests run in parallel after builder-image completes
+  velox-exec-test:
+    # velox_exec_test takes 15+ minutes to run (981 seconds observed), which is significantly
+    # longer than all other tests combined. Running it separately allows other tests to complete
+    # quickly while this long-running test executes in parallel.
+    #
+    # To separate additional slow tests in the future:
+    # 1. Create a new job similar to this one with -R "test_name" to run only that test
+    # 2. Update the other-tests job to exclude it using -E "test_name_1|test_name_2|..."
+    #    (use pipe | to exclude multiple tests with regex pattern)
+    name: Build and Test Velox (velox_exec_test)
+    needs: builder-image
+    runs-on: self-hosted
+    container:
+      # Image tag is dynamically generated based on dependency hash (intentionally unpinned)
+      # Gets the image from builder-image job output (e.g., ghcr.io/y-scope/velox/...:a1b2c3d4e5f6)
+      image: ${{ needs.builder-image.outputs.image-tag }}
     env:
-      CCACHE_COMPRESSLEVEL: 2
-      CCACHE_MAX_SIZE: 5G
       USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
-    defaults:
-      run:
-        shell: bash
-        working-directory: velox
     steps:
       - uses: actions/checkout@v4
         with:
-          path: velox
           persist-credentials: false
-
-      - name: Install Dependencies
-        run: |
-          source scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Clear CCache Statistics
         run: |
-          ccache -sz
+          # Clear ccache statistics (not the cache itself) so final stats reflect only this build
+          # The actual cached compilation results from the warmup build are preserved
+          ccache -z
 
-      - name: Build Artifact
+      - name: Build Velox
         env:
-          VELOX_DEPENDENCY_SOURCE: BUNDLED
-          Boost_SOURCE: SYSTEM
-          ICU_SOURCE: SYSTEM
-          MAKEFLAGS: MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3
+          # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)
+          # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
+          # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
+          # Self-hosted runners have more cores/RAM, so can handle higher parallelism
+          MAKEFLAGS: >-
+            MAX_HIGH_MEM_JOBS=${{ contains(runner.labels, 'self-hosted') && '16' || '4' }}
+            MAX_LINK_JOBS=${{ contains(runner.labels, 'self-hosted') && '12' || '3' }}
+        run: |
+          # Use Clang compiler if requested (e.g., scheduled.yml uses Clang for compiler diversity)
+          # Otherwise defaults to GCC (default CC/CXX in the container)
+          if [[ "${USE_CLANG}" = "true" ]]; then export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; fi
+          make release
+
+      - name: Show CCache Stats After Build
+        run: |
+          ccache -vs
+
+      - name: Run velox_exec_test
+        run: |
+          # Run only velox_exec_test which takes ~16 minutes
+          # -R: Run tests matching regex pattern (only velox_exec_test)
+          # -j: Parallel execution using all available CPUs
+          cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \
+            -R "velox_exec_test"
+
+  # Third job: run all other tests (excluding velox_exec_test) in parallel with velox-exec-test
+  other-tests:
+    name: Build and Test Velox (other tests)
+    needs: builder-image
+    runs-on: self-hosted
+    container:
+      # Image tag is dynamically generated based on dependency hash (intentionally unpinned)
+      # Gets the same image as velox-exec-test job (both run in parallel using same image)
+      image: ${{ needs.builder-image.outputs.image-tag }}
+    env:
+      USE_CLANG: ${{ inputs.use-clang && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Clear CCache Statistics
+        run: |
+          # Clear ccache statistics (not the cache itself) so final stats reflect only this build
+          # The actual cached compilation results from the warmup build are preserved
+          ccache -z
+
+      - name: Build Velox
+        env:
+          # Tune parallelism based on runner type: self-hosted (16-core) vs GitHub-hosted (4-core)
+          # MAX_HIGH_MEM_JOBS: High-memory compilation tasks (templates, large TUs)
+          # MAX_LINK_JOBS: Parallel linking tasks (memory-intensive)
+          MAKEFLAGS: >-
+            MAX_HIGH_MEM_JOBS=${{ contains(runner.labels, 'self-hosted') && '16' || '4' }}
+            MAX_LINK_JOBS=${{ contains(runner.labels, 'self-hosted') && '12' || '3' }}
         run: |
           if [[ "${USE_CLANG}" = "true" ]]; then export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; fi
           make release
 
-      - name: CCache after
+      - name: Show CCache Stats After Build
         run: |
           ccache -vs
 
-      - name: Run Tests
+      - name: Run Other Tests (excluding velox_exec_test)
         run: |
-          cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error
+          # Increase file descriptor limit to prevent "Too many open files" errors
+          # Required by velox_table_evolution_fuzzer_test which opens many files concurrently
+          ulimit -n 8192
+          # Run all tests except velox_exec_test which takes 16+ minutes and runs in parallel
+          # -E: Exclude tests matching regex pattern (velox_exec_test runs in separate job)
+          # -j: Parallel execution using all available CPUs
+          cd _build/release && ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure --no-tests=error \
+            -E "velox_exec_test"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -16,8 +16,6 @@ name: Linux Build using GCC
 
 on:
   push:
-    branches:
-      - presto-0.293-clp-connector
     paths:
       - velox/**
       - '!velox/docs/**'
@@ -45,10 +43,16 @@ on:
 
 permissions:
   contents: read
+  # packages: write needed to publish Docker images to GitHub Container Registry (ghcr.io)
+  packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
-  cancel-in-progress: ${{github.ref != 'refs/heads/presto-0.293-clp-connector'}}
+  # Group by workflow name and git ref (branch/tag/PR) to prevent concurrent runs on same ref
+  # This prevents multiple builds from running simultaneously on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel in-progress runs when new commits are pushed to the same ref
+  # Saves CI resources by stopping outdated builds
+  cancel-in-progress: true
 
 jobs:
   linux-gcc:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,11 +47,9 @@ permissions:
   packages: write
 
 concurrency:
-  # Group by workflow name and git ref (branch/tag/PR) to prevent concurrent runs on same ref
-  # This prevents multiple builds from running simultaneously on the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel in-progress runs when new commits are pushed to the same ref
-  # Saves CI resources by stopping outdated builds
+  # Group by workflow name and branch to prevent concurrent runs on same branch
+  # For pull_request, use head_ref (source branch) so push and PR events share the same group
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,8 +47,8 @@ permissions:
   # Necessary to publish Docker images to GitHub's container registry (ghcr.io)
   packages: write
 
-# For PRs: Groups by branch name, so pushing to the same PR cancels previous runs.
-# For pushes to main: Groups by commit SHA, so every merge is tested independently.
+# For PRs: Group by branch name, so pushing to the same PR cancels previous runs.
+# For pushes to main: Group by commit SHA, so every merge is tested independently.
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -43,15 +43,12 @@ on:
 
 permissions:
   contents: read
-  # packages: write needed to publish Docker images to GitHub Container Registry (ghcr.io)
+
+  # Necessary to publish Docker images to GitHub's container registry (ghcr.io)
   packages: write
 
 concurrency:
-  # Cancel duplicate runs for the same branch. Uses github.head_ref for pull_request (source branch
-  # name, e.g., "ci") and falls back to github.ref_name for push (branch name without refs/heads/).
-  # This ensures both events resolve to the same group (e.g., "Linux Build using GCC - ci").
-  # See: https://github.com/orgs/community/discussions/30794
-  group: ${{ github.workflow }} - ${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,6 +47,8 @@ permissions:
   # Necessary to publish Docker images to GitHub's container registry (ghcr.io)
   packages: write
 
+# For PRs: Groups by branch name, so pushing to the same PR cancels previous runs.
+# For pushes to main: Groups by commit SHA, so every merge is tested independently.
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,9 +47,11 @@ permissions:
   packages: write
 
 concurrency:
-  # Group by workflow name and branch to prevent concurrent runs on same branch
-  # For pull_request, use head_ref (source branch) so push and PR events share the same group
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  # Cancel duplicate runs for the same branch. Uses github.head_ref for pull_request (source branch
+  # name, e.g., "ci") and falls back to github.ref_name for push (branch name without refs/heads/).
+  # This ensures both events resolve to the same group (e.g., "Linux Build using GCC - ci").
+  # See: https://github.com/orgs/community/discussions/30794
+  group: ${{ github.workflow }} - ${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -64,8 +64,9 @@ jobs:
           # Docker doesn't support repository names with uppercase characters, so we convert the
           # name to lowercase here.
           REPO_LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
-          REF="ghcr.io/${REPO_LOWER}/y-scope-velox-builder:${DEPS_HASH}"
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          IMAGE="ghcr.io/${REPO_LOWER}/y-scope-velox-builder"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "ref=${IMAGE}:${DEPS_HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -94,7 +95,7 @@ jobs:
         if: steps.check-image.outputs.exists == 'false'
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ${{ steps.image-ref.outputs.ref }}
+          images: ${{ steps.image-ref.outputs.image }}
 
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       image-ref: ${{ steps.image-ref.outputs.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -97,11 +97,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push builder image
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: scripts/docker/yscope-velox-builder.dockerfile

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -35,7 +35,12 @@ permissions:
 jobs:
   builder-image:
     name: Build and publish builder image
-    runs-on: [self-hosted, cores=32]
+    runs-on: >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     outputs:
       # This output is used by calling workflows to get the image tag
       image-tag: ${{ steps.image-tag.outputs.tag }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -107,6 +107,8 @@ jobs:
           context: .
           file: scripts/docker/yscope-velox-builder.dockerfile
           push: true
-          # NOTE: `tags` expects a full image reference (e.g., ghcr.io/owner/repo:hash), not just the tag portion
+
+          # NOTE: `tags` expects a full image reference (e.g., ghcr.io/owner/repo:hash), not just
+          # the part after the colon (':').
           tags: ${{ steps.image-ref.outputs.ref }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -36,11 +36,11 @@ jobs:
   builder-image:
     name: Build and publish builder image
     runs-on: >-
-        ${{
-            github.repository_owner == 'y-scope'
-            && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
-            || 'ubuntu-latest'
-        }}
+      ${{
+          github.repository_owner == 'y-scope'
+          && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
+          || 'ubuntu-latest'
+      }}
     outputs:
       # This output is used by calling workflows to get the image tag
       image-tag: ${{ steps.image-tag.outputs.tag }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -1,0 +1,109 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build Velox Builder Image
+
+on:
+  # Called by other workflows (e.g., linux-build-base.yml) to get the builder image
+  workflow_call:
+    outputs:
+      image-tag:
+        description: Fully qualified Docker image tag (ghcr.io/owner/repo/image:hash)
+        value: ${{ jobs.builder-image.outputs.image-tag }}
+  # Allow manual trigger via GitHub Actions UI for rebuilding the image on-demand
+  workflow_dispatch: {}
+  # Automatically rebuild image when dependency installation scripts change
+  push:
+    paths:
+      - scripts/**
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  builder-image:
+    name: Build and publish builder image
+    runs-on: [self-hosted, cores=32]
+    outputs:
+      # This output is used by calling workflows to get the image tag
+      image-tag: ${{ steps.image-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Calculate dependency hash
+        id: deps-hash
+        run: |
+          # Use hashFiles for deterministic hashing of dependency files
+          # Only hash scripts/** to avoid rebuilding when workflow logic changes
+          HASH="${{ hashFiles('scripts/**') }}"
+          # Take first 12 characters for shorter tag (e.g., "a1b2c3d4e5f6")
+          SHORT_HASH="${HASH:0:12}"
+          echo "hash=${SHORT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "Dependency hash: ${SHORT_HASH}"
+
+      - name: Set image tag
+        id: image-tag
+        env:
+          DEPS_HASH: ${{ steps.deps-hash.outputs.hash }}
+        run: |
+          # GHCR requires lowercase repository names (owner/repo)
+          # Example: "y-scope/velox" -> "y-scope/velox"
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          # Final tag format: ghcr.io/y-scope/velox/y-scope-velox-builder:a1b2c3d4e5f6
+          TAG="ghcr.io/${REPO_LOWER}/y-scope-velox-builder:${DEPS_HASH}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Image tag: ${TAG}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image exists
+        id: check-image
+        continue-on-error: true
+        env:
+          IMAGE_TAG: ${{ steps.image-tag.outputs.tag }}
+        run: |
+          # Use docker manifest inspect to check remote registry without pulling
+          # This is more efficient than docker pull for existence checks
+          # If image with this hash already exists, we can skip the ~60min rebuild
+          if docker manifest inspect "${IMAGE_TAG}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image already exists, skipping build"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image does not exist, will build"
+          fi
+
+      # Only run the following steps if image doesn't exist (conditional on exists == 'false')
+      # Docker Buildx is required for docker/build-push-action to build and push images
+      # It provides advanced build features like multi-stage builds and efficient layer caching
+      - name: Set up Docker Buildx
+        if: steps.check-image.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push builder image
+        if: steps.check-image.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scripts/docker/yscope-velox-builder.dockerfile
+          push: true
+          tags: ${{ steps.image-tag.outputs.tag }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -18,12 +18,11 @@ on:
   # Called by other workflows (e.g., linux-build-base.yml) to get the builder image
   workflow_call:
     outputs:
-      image-tag:
-        description: Fully qualified Docker image tag (ghcr.io/owner/repo/image:hash)
-        value: ${{ jobs.builder-image.outputs.image-tag }}
-  # Allow manual trigger via GitHub Actions UI for rebuilding the image on-demand
+      image-ref:
+        description: Fully qualified Docker image reference (e.g., ghcr.io/owner/repo/image:hash)
+        value: ${{ jobs.builder-image.outputs.image-ref }}
   workflow_dispatch: {}
-  # Automatically rebuild image when dependency installation scripts change
+
   push:
     paths:
       - scripts/**
@@ -42,36 +41,31 @@ jobs:
           || 'ubuntu-latest'
       }}
     outputs:
-      # This output is used by calling workflows to get the image tag
-      image-tag: ${{ steps.image-tag.outputs.tag }}
+      image-ref: ${{ steps.image-ref.outputs.ref }}
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Calculate dependency hash
+      - name: Hash the dependency scripts
         id: deps-hash
         run: |
-          # Use hashFiles for deterministic hashing of dependency files
-          # Only hash scripts/** to avoid rebuilding when workflow logic changes
           HASH="${{ hashFiles('scripts/**') }}"
-          # Take first 12 characters for shorter tag (e.g., "a1b2c3d4e5f6")
-          SHORT_HASH="${HASH:0:12}"
-          echo "hash=${SHORT_HASH}" >> "$GITHUB_OUTPUT"
-          echo "Dependency hash: ${SHORT_HASH}"
 
-      - name: Set image tag
-        id: image-tag
+          # Truncate to 7 characters (Git's default short hash length)
+          SHORT_HASH="${HASH:0:7}"
+          echo "hash=${SHORT_HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: Set image ref
+        id: image-ref
         env:
           DEPS_HASH: ${{ steps.deps-hash.outputs.hash }}
         run: |
-          # GHCR requires lowercase repository names (owner/repo)
-          # Example: "y-scope/velox" -> "y-scope/velox"
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          # Final tag format: ghcr.io/y-scope/velox/y-scope-velox-builder:a1b2c3d4e5f6
-          TAG="ghcr.io/${REPO_LOWER}/y-scope-velox-builder:${DEPS_HASH}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Image tag: ${TAG}"
+          # Docker doesn't support repository names with uppercase characters, so we convert the
+          # name to lowercase here.
+          REPO_LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+          REF="ghcr.io/${REPO_LOWER}/y-scope-velox-builder:${DEPS_HASH}"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -84,12 +78,10 @@ jobs:
         id: check-image
         continue-on-error: true
         env:
-          IMAGE_TAG: ${{ steps.image-tag.outputs.tag }}
+          IMAGE_REF: ${{ steps.image-ref.outputs.ref }}
         run: |
-          # Use docker manifest inspect to check remote registry without pulling
-          # This is more efficient than docker pull for existence checks
-          # If image with this hash already exists, we can skip the ~60min rebuild
-          if docker manifest inspect "${IMAGE_TAG}" > /dev/null 2>&1; then
+          # NOTE: For existence checks, this is more efficient than `docker pull`.
+          if docker manifest inspect "${IMAGE_REF}" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Image already exists, skipping build"
           else
@@ -97,9 +89,6 @@ jobs:
             echo "Image does not exist, will build"
           fi
 
-      # Only run the following steps if image doesn't exist (conditional on exists == 'false')
-      # Docker Buildx is required for docker/build-push-action to build and push images
-      # It provides advanced build features like multi-stage builds and efficient layer caching
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
         uses: docker/setup-buildx-action@v3
@@ -111,4 +100,5 @@ jobs:
           context: .
           file: scripts/docker/yscope-velox-builder.dockerfile
           push: true
-          tags: ${{ steps.image-tag.outputs.tag }}
+          # NOTE: `tags` expects a full image reference (e.g., ghcr.io/owner/repo:hash), not just the tag portion
+          tags: ${{ steps.image-ref.outputs.ref }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       image-ref: ${{ steps.image-ref.outputs.ref }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,17 +92,17 @@ jobs:
       - name: Extract GitHub metadata
         id: meta
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ steps.image-ref.outputs.ref }}
 
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push builder image
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: scripts/docker/yscope-velox-builder.dockerfile

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -36,11 +36,11 @@ jobs:
   builder-image:
     name: Build and publish builder image
     runs-on: >-
-      ${{
-        github.repository_owner == 'y-scope'
-        && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
-        || 'ubuntu-latest'
-      }}
+        ${{
+            github.repository_owner == 'y-scope'
+            && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
+            || 'ubuntu-latest'
+        }}
     outputs:
       # This output is used by calling workflows to get the image tag
       image-tag: ${{ steps.image-tag.outputs.tag }}

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Extract GitHub metadata
         id: meta
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ steps.image-ref.outputs.ref }}
 

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -89,6 +89,12 @@ jobs:
             echo "Image does not exist, will build"
           fi
 
+      - name: Extract GitHub metadata
+        if: steps.check-image.outputs.exists == 'false'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{steps.image-tag.outputs.tag}}
+
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/yscope-velox-builder-img.yml
+++ b/.github/workflows/yscope-velox-builder-img.yml
@@ -90,10 +90,11 @@ jobs:
           fi
 
       - name: Extract GitHub metadata
+        id: meta
         if: steps.check-image.outputs.exists == 'false'
         uses: docker/metadata-action@v5
         with:
-          images: ${{steps.image-tag.outputs.tag}}
+          images: ${{ steps.image-ref.outputs.ref }}
 
       - name: Set up Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
@@ -108,3 +109,4 @@ jobs:
           push: true
           # NOTE: `tags` expects a full image reference (e.g., ghcr.io/owner/repo:hash), not just the tag portion
           tags: ${{ steps.image-ref.outputs.ref }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,10 +15,3 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
-
-  # linux-build-base.yml uses ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
-  # which is our own self-maintained image - we intentionally use the floating tag to
-  # receive security and maintenance updates automatically
-  unpinned-images:
-    ignore:
-      - linux-build-base.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,6 +15,7 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
+
   # linux-build-base.yml uses ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
   # which is our own self-maintained image - we intentionally use the floating tag to
   # receive security and maintenance updates automatically

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -22,9 +22,3 @@ rules:
   unpinned-images:
     ignore:
       - linux-build-base.yml
-  # yscope-velox-builder-img.yml uses actions/checkout and other first-party GitHub actions
-  # without SHA pinning. For official GitHub-maintained actions, using version tags (e.g., @v4)
-  # allows automatic security patches while maintaining reasonable trust in GitHub's own repos.
-  unpinned-uses:
-    ignore:
-      - yscope-velox-builder-img.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,3 +15,10 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
+
+  # linux-build-base.yml uses ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
+  # which is our own self-maintained image - we intentionally use the floating tag to
+  # receive security and maintenance updates automatically
+  unpinned-images:
+    ignore:
+      - linux-build-base.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,9 +15,15 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
+  # linux-build-base.yml uses ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
+  # which is our own self-maintained image - we intentionally use the floating tag to
+  # receive security and maintenance updates automatically
   unpinned-images:
     ignore:
       - linux-build-base.yml
+  # yscope-velox-builder-img.yml uses actions/checkout and other first-party GitHub actions
+  # without SHA pinning. For official GitHub-maintained actions, using version tags (e.g., @v4)
+  # allows automatic security patches while maintaining reasonable trust in GitHub's own repos.
   unpinned-uses:
     ignore:
       - yscope-velox-builder-img.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,3 +15,9 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
+  unpinned-images:
+    ignore:
+      - linux-build-base.yml
+  unpinned-uses:
+    ignore:
+      - yscope-velox-builder-img.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,9 +16,8 @@ rules:
     ignore:
       - build_pyvelox.yml
 
-  # linux-build-base.yml uses ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
-  # which is our own self-maintained image - we intentionally use the floating tag to
-  # receive security and maintenance updates automatically
   unpinned-images:
     ignore:
+      # linux-build-base.yml builds and publishes a container image which we then use immediately;
+      # so we need to use the images dynamically generated (i.e., unpinned) tag.
       - linux-build-base.yml

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -34,8 +34,6 @@ RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/
    && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
    && rm cmake-3.28.3-linux-x86_64.sh
 
-# Run the setup script to install all dependencies, then move venv to /opt and clean up
-# Note: setup-ubuntu.sh creates venv at SCRIPTDIR/../.venv (i.e., /tmp/.venv)
 RUN /tmp/velox-deps/setup-ubuntu.sh \
  && mv /tmp/.venv /opt/velox-venv \
  && rm -rf /tmp/velox-deps

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -24,11 +24,10 @@ COPY scripts /tmp/velox-deps/
 ENV TZ=Etc/UTC
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install CMake 3.28.3 using official binary installer
-# NOTE: setup-ubuntu.sh installs cmake via pip, but pip-installed cmake is not reliably found
-# in container environments, causing FastFloat library build failures. Using the official
-# binary installer ensures cmake is available and dependencies build correctly in the current
-# CI containerized environment.
+# Install CMake 3.28.3 using its install script
+# NOTE: `scripts/setup-ubuntu.sh` installs CMake via pip, but sometimes the pip-installed CMake
+# doesn't show up on the path in container environments (causing, for example, FastFloat library
+# build 1failures). Using CMake's install script avoids this issue.
 RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
    && chmod +x cmake-3.28.3-linux-x86_64.sh \
    && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -63,10 +63,12 @@ WORKDIR /tmp/velox-src
 
 # Build velox once to populate ccache with compilation results.
 # CCACHE_BASEDIR is set to the source location so cache keys use relative paths.
+# Stats are cleared after warmup so CI builds show only their own cache hits.
 RUN source /opt/velox-venv/bin/activate && \
     CCACHE_BASEDIR=/tmp/velox-src make release && \
     echo "CCache statistics after warmup build:" && \
-    ccache -vs
+    ccache -vs && \
+    ccache -z
 
 # Remove warmup source files (ccache in /var/cache/ccache is preserved)
 RUN rm -rf /tmp/velox-src

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -29,7 +29,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # in container environments, causing FastFloat library build failures. Using the official
 # binary installer ensures cmake is available and dependencies build correctly in the current
 # CI containerized environment.
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
+RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
  && chmod +x cmake-3.28.3-linux-x86_64.sh \
  && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
  && rm cmake-3.28.3-linux-x86_64.sh
@@ -76,6 +76,4 @@ RUN source /velox/.venv/bin/activate && \
 # Remove source files but keep ccache
 # The compiled binaries and source are deleted - we only need the ccache artifacts.
 # CI workflows will check out fresh source code at runtime into this same directory.
-RUN rm -rf /__w/velox/velox/*
-
-WORKDIR /__w/velox/velox
+RUN rm -rf /__w/velox/velox/* && echo "Removed source files, ccache preserved"

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -61,16 +61,17 @@ ENV CCACHE_NOHASHDIR=true
 COPY . /tmp/velox-src/
 WORKDIR /tmp/velox-src
 
-# Build velox once to populate ccache with compilation results.
-# CCACHE_BASEDIR is set to the source location so cache keys use relative paths.
-# Stats are cleared after warmup so CI builds show only their own cache hits.
-RUN source /opt/velox-venv/bin/activate && \
-    CCACHE_BASEDIR=/tmp/velox-src make release && \
-    echo "CCache statistics after warmup build:" && \
-    ccache -vs && \
-    ccache -z
-
-# Remove warmup source files (ccache in /var/cache/ccache is preserved)
+# Build velox once to warm up ccache
+# NOTE:
+# - We set `CCACHE_BASEDIR` so cache keys use relative paths.
+# - We clear the stats after warmup so that CI builds only show their own cache hits.
+COPY . /tmp/velox-src/
+WORKDIR /tmp/velox-src
+RUN source /opt/velox-venv/bin/activate \
+    && CCACHE_BASEDIR=/tmp/velox-src make release \
+    && echo "CCache statistics after warmup build:" \
+    && ccache --verbose --show-stats \
+    && ccache --zero-stats
 RUN rm -rf /tmp/velox-src
 
 WORKDIR /

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -40,11 +40,10 @@ RUN /tmp/velox-deps/setup-ubuntu.sh \
 
 # Activate the virtual environment.
 #
-# NOTE: We set `ENV` variables directly rather than using `source /opt/velox-venv/bin/activate`
-# in a RUN command since activation in a RUN command only persists for that single instruction
-# (each RUN starts a fresh shell). By setting PATH and VIRTUAL_ENV via ENV, these values are
-# baked into the Docker image and persist across all subsequent RUN commands and any containers
-# started from the final image.
+# NOTE: We set `ENV` variables directly rather than using `source /opt/velox-venv/bin/activate` in
+# a `RUN` command since the latter only persists for that single instruction (each `RUN` starts a
+# fresh shell), whereas the former persists across all subsequent `RUN` commands and in containers
+# that use the image.
 ENV VIRTUAL_ENV="/opt/velox-venv"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -53,6 +53,7 @@ ENV CCACHE_DIR=/var/cache/ccache
 # Disable compression to trade disk space for speed in CI builds
 ENV CCACHE_COMPRESSLEVEL=0
 ENV CCACHE_MAXSIZE=5G
+
 # Ignore working directory in cache keys so warmup cache (built in /tmp/velox-src/) is reused
 # by CI builds (which run in /__w/velox/velox/)
 ENV CCACHE_NOHASHDIR=true

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builder image with dependencies and pre-populated ccache for faster CI builds
+FROM ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Copy all scripts needed for dependency installation
+COPY scripts /velox/scripts/
+
+# Set timezone to avoid interactive prompts during apt installations
+ENV TZ=Etc/UTC
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install CMake 3.28.3 using official binary installer
+# NOTE: setup-ubuntu.sh installs cmake via pip, but pip-installed cmake is not reliably found
+# in container environments, causing FastFloat library build failures. Using the official
+# binary installer ensures cmake is available and dependencies build correctly in the current
+# CI containerized environment.
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
+ && chmod +x cmake-3.28.3-linux-x86_64.sh \
+ && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
+ && rm cmake-3.28.3-linux-x86_64.sh
+
+# Run the setup script to install all dependencies
+# Run exactly as you would on a laptop - no special environment variables
+RUN /velox/scripts/setup-ubuntu.sh
+
+# Set up environment to use the Python venv created by setup script
+ENV PATH="/velox/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/velox/.venv"
+
+# Configure ccache with BASEDIR matching GitHub Actions workspace path
+# CCACHE_BASEDIR: Must match the path where source will be checked out in CI (/__w/velox/velox)
+#                 so that cache keys generated during warmup build match CI runtime builds
+# CCACHE_NOHASHDIR: Ignores absolute directory paths in cache keys, using only relative paths
+#                   from BASEDIR. Critical for cache hits across different checkouts - without
+#                   this, ccache would see warmup build files vs CI checkout files as different
+#                   due to file metadata/inode differences, causing cache misses
+# CCACHE_COMPRESSLEVEL: Disabled (0) for faster CI execution - trading disk space for speed
+# CCACHE_MAX_SIZE: 5GB quota (actual usage typically a few hundred MB)
+ENV CCACHE_DIR=/velox/.ccache
+ENV CCACHE_BASEDIR=/__w/velox/velox
+ENV CCACHE_COMPRESSLEVEL=0
+ENV CCACHE_MAX_SIZE=5G
+ENV CCACHE_NOHASHDIR=true
+
+# Copy velox source to match GitHub Actions workspace path
+# This is a temporary copy used only for the warmup build to populate ccache.
+# The source will be deleted after the warmup build (see below), and CI workflows
+# will check out fresh source into the same path for actual builds.
+COPY . /__w/velox/velox/
+WORKDIR /__w/velox/velox
+
+# Build velox once to populate ccache with compilation results
+# This "warmup build" compiles all source files and stores the results in ccache.
+# In CI, fresh checkouts will benefit from these cached compilation results since
+# CCACHE_NOHASHDIR makes cache keys path-independent (only content matters).
+RUN source /velox/.venv/bin/activate && \
+    make release && \
+    echo "CCache statistics after warmup build:" && \
+    ccache -vs
+
+# Remove source files but keep ccache
+# The compiled binaries and source are deleted - we only need the ccache artifacts.
+# CI workflows will check out fresh source code at runtime into this same directory.
+RUN rm -rf /__w/velox/velox/*
+
+WORKDIR /__w/velox/velox

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 # Builder image with dependencies and pre-populated ccache for faster CI builds
-FROM ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
+FROM ghcr.io/myoung34/docker-github-actions-runner:ubuntu-jammy
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# First, copy the dependency installation scripts to optimize Docker layer caching
-COPY scripts /tmp/velox-deps/
 
 # Set timezone to avoid interactive prompts during apt installations
 ENV TZ=Etc/UTC
@@ -27,35 +24,37 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install CMake 3.28.3 using its install script
 # NOTE: `scripts/setup-ubuntu.sh` installs CMake via pip, but sometimes the pip-installed CMake
 # doesn't show up on the path in container environments (causing, for example, FastFloat library
-# build 1failures). Using CMake's install script avoids this issue.
-RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
-   && chmod +x cmake-3.28.3-linux-x86_64.sh \
-   && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
-   && rm cmake-3.28.3-linux-x86_64.sh
+# build failures). Using CMake's install script avoids this issue.
+RUN curl --fail --location --show-error --silent --remote-name \
+        https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
+    && chmod +x cmake-3.28.3-linux-x86_64.sh \
+    && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
+    && rm cmake-3.28.3-linux-x86_64.sh
+
+# Copy dependency installation scripts (after rarely-changing layers for better caching)
+COPY scripts /tmp/velox-deps/
 
 RUN /tmp/velox-deps/setup-ubuntu.sh \
-   && mv /tmp/.venv /opt/velox-venv \
-   && rm -rf /tmp/velox-deps
+    && mv /tmp/.venv /opt/velox-venv \
+    && rm -rf /tmp/velox-deps
 
-# Activate the virtual environment by setting ENV variables directly rather than using
-# `source /opt/velox-venv/bin/activate` in a RUN command. This is because activation in a RUN
-# command only persists for that single instruction - each RUN starts a fresh shell. By setting
-# PATH and VIRTUAL_ENV via ENV, these values are baked into the Docker image and persist across:
-# 1. All subsequent RUN commands in the Dockerfile
-# 2. Any containers started from the final image (e.g., CI workflows can directly run commands
-#    like `make release` or `python` without needing to activate the venv first)
+# Activate the virtual environment.
+#
+# NOTE: We set `ENV` variables directly rather than using `source /opt/velox-venv/bin/activate`
+# in a RUN command since activation in a RUN command only persists for that single instruction
+# (each RUN starts a fresh shell). By setting PATH and VIRTUAL_ENV via ENV, these values are
+# baked into the Docker image and persist across all subsequent RUN commands and any containers
+# started from the final image.
 ENV VIRTUAL_ENV="/opt/velox-venv"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-# Configure ccache settings
-# CCACHE_BASEDIR: Must be set at runtime to your source checkout path for cache hits.
-#                 Example: export CCACHE_BASEDIR=$GITHUB_WORKSPACE (CI) or /path/to/velox (local)
-# CCACHE_NOHASHDIR: Ignores working directory in cache keys - only file content matters.
-# CCACHE_COMPRESSLEVEL: Disabled (0) for faster CI execution - trading disk space for speed.
-# CCACHE_MAX_SIZE: 5GB quota (actual usage typically a few hundred MB).
 ENV CCACHE_DIR=/var/cache/ccache
+
+# Disable compression to trade disk space for speed in CI builds
 ENV CCACHE_COMPRESSLEVEL=0
-ENV CCACHE_MAX_SIZE=5G
+ENV CCACHE_MAXSIZE=5G
+# Ignore working directory in cache keys so warmup cache (built in /tmp/velox-src/) is reused
+# by CI builds (which run in /__w/velox/velox/)
 ENV CCACHE_NOHASHDIR=true
 
 # Copy velox source for warmup build to populate ccache

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -32,9 +32,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # binary installer ensures cmake is available and dependencies build correctly in the current
 # CI containerized environment.
 RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh \
- && chmod +x cmake-3.28.3-linux-x86_64.sh \
- && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
- && rm cmake-3.28.3-linux-x86_64.sh
+   && chmod +x cmake-3.28.3-linux-x86_64.sh \
+   && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
+   && rm cmake-3.28.3-linux-x86_64.sh
 
 # Run the setup script to install all dependencies, then move venv to /opt and clean up
 # Note: setup-ubuntu.sh creates venv at SCRIPTDIR/../.venv (i.e., /tmp/.venv)

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -42,7 +42,7 @@ RUN /tmp/velox-deps/setup-ubuntu.sh \
  && mv /tmp/.venv /opt/velox-venv \
  && rm -rf /tmp/velox-deps
 
-# Set up environment to use the Python venv
+# Activate the virtual environment
 ENV PATH="/opt/velox-venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/opt/velox-venv"
 

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -17,9 +17,7 @@ FROM ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Copy only scripts first for dependency installation.
-# This optimizes Docker layer caching: changes to other source files won't invalidate
-# the dependency installation layer - it only rebuilds when scripts change.
+# First, copy the dependency installation scripts to optimize Docker layer caching
 COPY scripts /tmp/velox-deps/
 
 # Set timezone to avoid interactive prompts during apt installations

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -57,14 +57,12 @@ ENV CCACHE_MAXSIZE=5G
 # by CI builds (which run in /__w/velox/velox/)
 ENV CCACHE_NOHASHDIR=true
 
-# Copy velox source for warmup build to populate ccache
-COPY . /tmp/velox-src/
-WORKDIR /tmp/velox-src
-
 # Build velox once to warm up ccache
 # NOTE:
 # - We set `CCACHE_BASEDIR` so cache keys use relative paths.
 # - We clear the stats after warmup so that CI builds only show their own cache hits.
+COPY . /tmp/velox-src/
+WORKDIR /tmp/velox-src
 RUN CCACHE_BASEDIR=/tmp/velox-src make release \
     && echo "CCache statistics after warmup build:" \
     && ccache --verbose --show-stats \

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -17,8 +17,10 @@ FROM ghcr.io/y-scope/docker-github-actions-runner:ubuntu-jammy
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Copy all scripts needed for dependency installation
-COPY scripts /velox/scripts/
+# Copy only scripts first for dependency installation.
+# This optimizes Docker layer caching: changes to other source files won't invalidate
+# the dependency installation layer - it only rebuilds when scripts change.
+COPY scripts /tmp/velox-deps/
 
 # Set timezone to avoid interactive prompts during apt installations
 ENV TZ=Etc/UTC
@@ -34,46 +36,39 @@ RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/
  && ./cmake-3.28.3-linux-x86_64.sh --skip-license --prefix=/usr/local \
  && rm cmake-3.28.3-linux-x86_64.sh
 
-# Run the setup script to install all dependencies
-# Run exactly as you would on a laptop - no special environment variables
-RUN /velox/scripts/setup-ubuntu.sh
+# Run the setup script to install all dependencies, then move venv to /opt and clean up
+# Note: setup-ubuntu.sh creates venv at SCRIPTDIR/../.venv (i.e., /tmp/.venv)
+RUN /tmp/velox-deps/setup-ubuntu.sh \
+ && mv /tmp/.venv /opt/velox-venv \
+ && rm -rf /tmp/velox-deps
 
-# Set up environment to use the Python venv created by setup script
-ENV PATH="/velox/.venv/bin:${PATH}"
-ENV VIRTUAL_ENV="/velox/.venv"
+# Set up environment to use the Python venv
+ENV PATH="/opt/velox-venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/opt/velox-venv"
 
-# Configure ccache with BASEDIR matching GitHub Actions workspace path
-# CCACHE_BASEDIR: Must match the path where source will be checked out in CI (/__w/velox/velox)
-#                 so that cache keys generated during warmup build match CI runtime builds
-# CCACHE_NOHASHDIR: Ignores absolute directory paths in cache keys, using only relative paths
-#                   from BASEDIR. Critical for cache hits across different checkouts - without
-#                   this, ccache would see warmup build files vs CI checkout files as different
-#                   due to file metadata/inode differences, causing cache misses
-# CCACHE_COMPRESSLEVEL: Disabled (0) for faster CI execution - trading disk space for speed
-# CCACHE_MAX_SIZE: 5GB quota (actual usage typically a few hundred MB)
-ENV CCACHE_DIR=/velox/.ccache
-ENV CCACHE_BASEDIR=/__w/velox/velox
+# Configure ccache settings
+# CCACHE_BASEDIR: Must be set at runtime to your source checkout path for cache hits.
+#                 Example: export CCACHE_BASEDIR=$GITHUB_WORKSPACE (CI) or /path/to/velox (local)
+# CCACHE_NOHASHDIR: Ignores working directory in cache keys - only file content matters.
+# CCACHE_COMPRESSLEVEL: Disabled (0) for faster CI execution - trading disk space for speed.
+# CCACHE_MAX_SIZE: 5GB quota (actual usage typically a few hundred MB).
+ENV CCACHE_DIR=/var/cache/ccache
 ENV CCACHE_COMPRESSLEVEL=0
 ENV CCACHE_MAX_SIZE=5G
 ENV CCACHE_NOHASHDIR=true
 
-# Copy velox source to match GitHub Actions workspace path
-# This is a temporary copy used only for the warmup build to populate ccache.
-# The source will be deleted after the warmup build (see below), and CI workflows
-# will check out fresh source into the same path for actual builds.
-COPY . /__w/velox/velox/
-WORKDIR /__w/velox/velox
+# Copy velox source for warmup build to populate ccache
+COPY . /tmp/velox-src/
+WORKDIR /tmp/velox-src
 
-# Build velox once to populate ccache with compilation results
-# This "warmup build" compiles all source files and stores the results in ccache.
-# In CI, fresh checkouts will benefit from these cached compilation results since
-# CCACHE_NOHASHDIR makes cache keys path-independent (only content matters).
-RUN source /velox/.venv/bin/activate && \
-    make release && \
+# Build velox once to populate ccache with compilation results.
+# CCACHE_BASEDIR is set to the source location so cache keys use relative paths.
+RUN source /opt/velox-venv/bin/activate && \
+    CCACHE_BASEDIR=/tmp/velox-src make release && \
     echo "CCache statistics after warmup build:" && \
     ccache -vs
 
-# Remove source files but keep ccache
-# The compiled binaries and source are deleted - we only need the ccache artifacts.
-# CI workflows will check out fresh source code at runtime into this same directory.
-RUN rm -rf /__w/velox/velox/* && echo "Removed source files, ccache preserved"
+# Remove warmup source files (ccache in /var/cache/ccache is preserved)
+RUN rm -rf /tmp/velox-src
+
+WORKDIR /

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -38,9 +38,15 @@ RUN /tmp/velox-deps/setup-ubuntu.sh \
    && mv /tmp/.venv /opt/velox-venv \
    && rm -rf /tmp/velox-deps
 
-# Activate the virtual environment
-ENV PATH="/opt/velox-venv/bin:${PATH}"
+# Activate the virtual environment by setting ENV variables directly rather than using
+# `source /opt/velox-venv/bin/activate` in a RUN command. This is because activation in a RUN
+# command only persists for that single instruction - each RUN starts a fresh shell. By setting
+# PATH and VIRTUAL_ENV via ENV, these values are baked into the Docker image and persist across:
+# 1. All subsequent RUN commands in the Dockerfile
+# 2. Any containers started from the final image (e.g., CI workflows can directly run commands
+#    like `make release` or `python` without needing to activate the venv first)
 ENV VIRTUAL_ENV="/opt/velox-venv"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Configure ccache settings
 # CCACHE_BASEDIR: Must be set at runtime to your source checkout path for cache hits.
@@ -61,8 +67,7 @@ WORKDIR /tmp/velox-src
 # NOTE:
 # - We set `CCACHE_BASEDIR` so cache keys use relative paths.
 # - We clear the stats after warmup so that CI builds only show their own cache hits.
-RUN source /opt/velox-venv/bin/activate \
-    && CCACHE_BASEDIR=/tmp/velox-src make release \
+RUN CCACHE_BASEDIR=/tmp/velox-src make release \
     && echo "CCache statistics after warmup build:" \
     && ccache --verbose --show-stats \
     && ccache --zero-stats

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -61,8 +61,6 @@ WORKDIR /tmp/velox-src
 # NOTE:
 # - We set `CCACHE_BASEDIR` so cache keys use relative paths.
 # - We clear the stats after warmup so that CI builds only show their own cache hits.
-COPY . /tmp/velox-src/
-WORKDIR /tmp/velox-src
 RUN source /opt/velox-venv/bin/activate \
     && CCACHE_BASEDIR=/tmp/velox-src make release \
     && echo "CCache statistics after warmup build:" \

--- a/scripts/docker/yscope-velox-builder.dockerfile
+++ b/scripts/docker/yscope-velox-builder.dockerfile
@@ -35,8 +35,8 @@ RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/
    && rm cmake-3.28.3-linux-x86_64.sh
 
 RUN /tmp/velox-deps/setup-ubuntu.sh \
- && mv /tmp/.venv /opt/velox-venv \
- && rm -rf /tmp/velox-deps
+   && mv /tmp/.venv /opt/velox-venv \
+   && rm -rf /tmp/velox-deps
 
 # Activate the virtual environment
 ENV PATH="/opt/velox-venv/bin:${PATH}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Replaced stateful self-hosted runner builds with ephemeral containerized execution using pre-built Docker images with cached dependencies, eliminating state accumulation and dependency conflicts while improving build reliability and test execution performance.

Migration from ubuntu-release (stateful direct runner) to containerized workflow:

1. Introduced Docker builder image for ephemeral execution:
   - Created yscope-velox-builder-img.yml to build and publish builder image
   - Image includes all dependencies and pre-populated ccache from warmup build
   - Cache key based on hash of scripts/** - image only rebuilt when dependencies change
   - Most builds reuse existing cached image, avoiding ~30min image build overhead
   - Published to ghcr.io with dynamic tagging for parallel workflow execution
   - Each job runs in fresh container with consistent, known state

2. Containerized build and test execution:
   - Replaced stateful runner with ephemeral container-based jobs
   - Aligned paths to GitHub Actions workspace (/__w/velox/velox)
   - Configured ccache with BASEDIR matching workspace for proper cache hits
   - Disabled ccache compression (COMPRESSLEVEL=0) for faster CI execution
   - Increased parallelism for self-hosted runners (16 high-mem jobs, 12 link jobs)
   - Containers automatically removed after job completion

3. Split tests into two parallel jobs (instead of single sequential job):
   - velox-exec-test: Runs only velox_exec_test (~16 minutes, the bottleneck)
   - other-tests: Runs all remaining tests in parallel
   - Both jobs build independently in separate ephemeral containers
   - Shared ccache provides fast builds despite independent execution
   - Total time ~25 minutes with better failure visibility

4. Test execution configuration:
   - Added ulimit -n 8192 for velox_table_evolution_fuzzer_test
   - Documented pattern for separating additional slow tests in future

5. CI configuration improvements:
   - Added workflow_dispatch trigger for manual workflow runs
   - Configured zizmor suppressions for intentionally unpinned images
   - Improved CMake installation documentation in Dockerfile

Benefits of ephemeral containerized approach vs stateful runner:
- Consistent, reproducible build environment (no state accumulation)
- Eliminates dependency conflicts from previous runs
- Faster builds via pre-populated ccache in builder image
- Image reused across most builds - only rebuilt when dependencies change
- Better resource utilization (parallel test execution in separate containers)
- Improved failure visibility (separate slow vs fast test jobs)
- No need to install dependencies on runner for each run
- Automatic cleanup (containers destroyed after job completion)
- Dynamic image caching reduces unnecessary rebuilds
- Scalable pattern for adding more parallel test jobs

This migration modernizes the CI pipeline from stateful runner execution to ephemeral containerized builds with optimized test parallelization.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Ran the CI workflows multiple times with success. For example:
- https://github.com/y-scope/velox/actions/runs/19681868579/job/56381881616


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable builder image and parallel build-and-test matrix with two test groups, per-group test args and ulimit, plus optional Clang selection.

* **Chores**
  * Split CI into image-build and build-and-test stages, use builder-image outputs to speed runs, adaptive MAKEFLAGS for runner type, cache alignment, updated concurrency and package-publish permission, and skip-if-exists image publishing.

* **Documentation**
  * Added ignore rule and explanatory comments for image publishing and workflow behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->