### PR TITLE
feat: Support metadata projection

### DIFF
--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -20,13 +20,15 @@
 
 namespace facebook::velox::connector::clp {
 
+using ColumnValue = std::variant<std::string, int64_t, double>;
+
 struct ClpConnectorSplit : public connector::ConnectorSplit {
   ClpConnectorSplit(
       const std::string& connectorId,
       const std::string& path,
       const int type,
       std::shared_ptr<std::string> kqlQuery,
-      std::shared_ptr<std::map<std::string, std::string>> projectionNameValue)
+      std::shared_ptr<std::map<std::string, ColumnValue>> projectionNameValue)
       : connector::ConnectorSplit(connectorId),
         path_(path),
         type_(static_cast<SplitType>(type)),
@@ -46,7 +48,7 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   const std::string path_;
   const SplitType type_;
   std::shared_ptr<std::string> kqlQuery_;
-  std::shared_ptr<std::map<std::string, std::string>> projectionNameValue_;
+  std::shared_ptr<std::map<std::string, ColumnValue>> projectionNameValue_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -20,7 +20,7 @@
 
 namespace facebook::velox::connector::clp {
 
-/// Metadata value type for projection (string, int64_t, or double).
+/// Metadata value type for projection.
 using MetadataValue = std::variant<std::string, int64_t, double>;
 
 struct ClpConnectorSplit : public connector::ConnectorSplit {

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -21,7 +21,7 @@
 namespace facebook::velox::connector::clp {
 
 /// Metadata value type for projection.
-using MetadataValue = std::variant<std::string, int64_t, double>;
+using MetadataValueType = std::variant<std::string, int64_t, double>;
 
 struct ClpConnectorSplit : public connector::ConnectorSplit {
   ClpConnectorSplit(
@@ -29,7 +29,7 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
       const std::string& path,
       const int type,
       std::shared_ptr<std::string> kqlQuery,
-      std::shared_ptr<std::map<std::string, MetadataValue>>
+      std::shared_ptr<std::map<std::string, MetadataValueType>>
           metadataColumnValues)
       : connector::ConnectorSplit(connectorId),
         path_(path),
@@ -50,8 +50,10 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   const std::string path_;
   const SplitType type_;
   std::shared_ptr<std::string> kqlQuery_;
-  /// Constant values for metadata columns.
-  std::shared_ptr<std::map<std::string, MetadataValue>> metadataColumnValues_;
+  /// Maps column names to constant values fetched from metadata database for
+  /// metadata projection.
+  std::shared_ptr<std::map<std::string, MetadataValueType>>
+      metadataColumnValues_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -25,11 +25,13 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
       const std::string& connectorId,
       const std::string& path,
       const int type,
-      std::shared_ptr<std::string> kqlQuery)
+      std::shared_ptr<std::string> kqlQuery,
+      std::shared_ptr<std::map<std::string, std::string>> projectionNameValue)
       : connector::ConnectorSplit(connectorId),
         path_(path),
         type_(static_cast<SplitType>(type)),
-        kqlQuery_(std::move(kqlQuery)) {}
+        kqlQuery_(std::move(kqlQuery)),
+        projectionNameValue_(std::move(projectionNameValue)) {}
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
@@ -44,6 +46,7 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   const std::string path_;
   const SplitType type_;
   std::shared_ptr<std::string> kqlQuery_;
+  std::shared_ptr<std::map<std::string, std::string>> projectionNameValue_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -20,7 +20,8 @@
 
 namespace facebook::velox::connector::clp {
 
-using ColumnValue = std::variant<std::string, int64_t, double>;
+/// Metadata value type for projection (string, int64_t, or double).
+using MetadataValue = std::variant<std::string, int64_t, double>;
 
 struct ClpConnectorSplit : public connector::ConnectorSplit {
   ClpConnectorSplit(
@@ -28,12 +29,12 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
       const std::string& path,
       const int type,
       std::shared_ptr<std::string> kqlQuery,
-      std::shared_ptr<std::map<std::string, ColumnValue>> projectionNameValue)
+      std::shared_ptr<std::map<std::string, MetadataValue>> metadataColumnValues)
       : connector::ConnectorSplit(connectorId),
         path_(path),
         type_(static_cast<SplitType>(type)),
         kqlQuery_(std::move(kqlQuery)),
-        projectionNameValue_(std::move(projectionNameValue)) {}
+        metadataColumnValues_(std::move(metadataColumnValues)) {}
 
   [[nodiscard]] std::string toString() const override {
     return fmt::format(
@@ -48,7 +49,8 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
   const std::string path_;
   const SplitType type_;
   std::shared_ptr<std::string> kqlQuery_;
-  std::shared_ptr<std::map<std::string, ColumnValue>> projectionNameValue_;
+  /// Constant values for metadata columns.
+  std::shared_ptr<std::map<std::string, MetadataValue>> metadataColumnValues_;
 };
 
 } // namespace facebook::velox::connector::clp

--- a/velox/connectors/clp/ClpConnectorSplit.h
+++ b/velox/connectors/clp/ClpConnectorSplit.h
@@ -29,7 +29,8 @@ struct ClpConnectorSplit : public connector::ConnectorSplit {
       const std::string& path,
       const int type,
       std::shared_ptr<std::string> kqlQuery,
-      std::shared_ptr<std::map<std::string, MetadataValue>> metadataColumnValues)
+      std::shared_ptr<std::map<std::string, MetadataValue>>
+          metadataColumnValues)
       : connector::ConnectorSplit(connectorId),
         path_(path),
         type_(static_cast<SplitType>(type)),

--- a/velox/connectors/clp/ClpDataSource.cpp
+++ b/velox/connectors/clp/ClpDataSource.cpp
@@ -127,8 +127,7 @@ void ClpDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   auto pushDownQuery = clpSplit->kqlQuery_;
   const std::map<std::string, MetadataValue> emptyMetadataMap;
-  const auto& metadataValues =
-    clpSplit->metadataColumnValues_
+  const auto& metadataValues = clpSplit->metadataColumnValues_
       ? *clpSplit->metadataColumnValues_
       : emptyMetadataMap;
 

--- a/velox/connectors/clp/ClpDataSource.cpp
+++ b/velox/connectors/clp/ClpDataSource.cpp
@@ -126,7 +126,7 @@ void ClpDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   }
 
   auto pushDownQuery = clpSplit->kqlQuery_;
-  const std::map<std::string, MetadataValue> emptyMetadataMap;
+  const std::map<std::string, MetadataValueType> emptyMetadataMap;
   const auto& metadataValues = clpSplit->metadataColumnValues_
       ? *clpSplit->metadataColumnValues_
       : emptyMetadataMap;

--- a/velox/connectors/clp/ClpDataSource.cpp
+++ b/velox/connectors/clp/ClpDataSource.cpp
@@ -127,9 +127,9 @@ void ClpDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   auto pushDownQuery = clpSplit->kqlQuery_;
   if (pushDownQuery && !pushDownQuery->empty()) {
-    cursor_->executeQuery(*pushDownQuery, fields_);
+    cursor_->executeQuery(*pushDownQuery, *clpSplit->projectionNameValue_, fields_);
   } else {
-    cursor_->executeQuery("*", fields_);
+    cursor_->executeQuery("*", *clpSplit->projectionNameValue_, fields_);
   }
 }
 

--- a/velox/connectors/clp/ClpDataSource.cpp
+++ b/velox/connectors/clp/ClpDataSource.cpp
@@ -127,9 +127,9 @@ void ClpDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   auto pushDownQuery = clpSplit->kqlQuery_;
   if (pushDownQuery && !pushDownQuery->empty()) {
-    cursor_->executeQuery(*pushDownQuery, *clpSplit->projectionNameValue_, fields_);
+    cursor_->executeQuery(*pushDownQuery, *clpSplit->metadataColumnValues_, fields_);
   } else {
-    cursor_->executeQuery("*", *clpSplit->projectionNameValue_, fields_);
+    cursor_->executeQuery("*", *clpSplit->metadataColumnValues_, fields_);
   }
 }
 

--- a/velox/connectors/clp/ClpDataSource.cpp
+++ b/velox/connectors/clp/ClpDataSource.cpp
@@ -126,10 +126,16 @@ void ClpDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   }
 
   auto pushDownQuery = clpSplit->kqlQuery_;
+  const std::map<std::string, MetadataValue> emptyMetadataMap;
+  const auto& metadataValues =
+    clpSplit->metadataColumnValues_
+      ? *clpSplit->metadataColumnValues_
+      : emptyMetadataMap;
+
   if (pushDownQuery && !pushDownQuery->empty()) {
-    cursor_->executeQuery(*pushDownQuery, *clpSplit->metadataColumnValues_, fields_);
+    cursor_->executeQuery(*pushDownQuery, metadataValues, fields_);
   } else {
-    cursor_->executeQuery("*", *clpSplit->metadataColumnValues_, fields_);
+    cursor_->executeQuery("*", metadataValues, fields_);
   }
 }
 

--- a/velox/connectors/clp/search_lib/BaseClpCursor.cpp
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.cpp
@@ -32,7 +32,7 @@ namespace facebook::velox::connector::clp::search_lib {
 
 void BaseClpCursor::executeQuery(
     const std::string& query,
-    const std::map<std::string, MetadataValue>& metadataColumnValues,
+    const std::map<std::string, MetadataValueType>& metadataColumnValues,
     const std::vector<Field>& outputColumns) {
   query_ = query;
   metadataColumnValues_ = metadataColumnValues;

--- a/velox/connectors/clp/search_lib/BaseClpCursor.cpp
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.cpp
@@ -32,8 +32,10 @@ namespace facebook::velox::connector::clp::search_lib {
 
 void BaseClpCursor::executeQuery(
     const std::string& query,
+    const std::map<std::string, std::string>& projectionNameValue,
     const std::vector<Field>& outputColumns) {
   query_ = query;
+  projectionNameValue_ = projectionNameValue;
   outputColumns_ = outputColumns;
   errorCode_ = preprocessQuery();
 }

--- a/velox/connectors/clp/search_lib/BaseClpCursor.cpp
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.cpp
@@ -32,10 +32,10 @@ namespace facebook::velox::connector::clp::search_lib {
 
 void BaseClpCursor::executeQuery(
     const std::string& query,
-    const std::map<std::string, ColumnValue>& projectionNameValue,
+    const std::map<std::string, MetadataValue>& metadataColumnValues,
     const std::vector<Field>& outputColumns) {
   query_ = query;
-  projectionNameValue_ = projectionNameValue;
+  metadataColumnValues_ = metadataColumnValues;
   outputColumns_ = outputColumns;
   errorCode_ = preprocessQuery();
 }

--- a/velox/connectors/clp/search_lib/BaseClpCursor.cpp
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.cpp
@@ -32,7 +32,7 @@ namespace facebook::velox::connector::clp::search_lib {
 
 void BaseClpCursor::executeQuery(
     const std::string& query,
-    const std::map<std::string, std::string>& projectionNameValue,
+    const std::map<std::string, ColumnValue>& projectionNameValue,
     const std::vector<Field>& outputColumns) {
   query_ = query;
   projectionNameValue_ = projectionNameValue;

--- a/velox/connectors/clp/search_lib/BaseClpCursor.h
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.h
@@ -75,7 +75,7 @@ class BaseClpCursor {
         splitPath_(std::string(splitPath)) {}
   virtual ~BaseClpCursor() = default;
 
-  using MetadataValue = std::variant<std::string, int64_t, double>;
+  using MetadataValueType = std::variant<std::string, int64_t, double>;
 
   /// Executes a query. This function parses, validates, and prepares the given
   /// query for execution.
@@ -86,7 +86,7 @@ class BaseClpCursor {
   /// query result.
   void executeQuery(
       const std::string& query,
-      const std::map<std::string, MetadataValue>& metadataColumnValues,
+      const std::map<std::string, MetadataValueType>& metadataColumnValues,
       const std::vector<Field>& outputColumns);
 
   /// Fetches the next set of rows from the cursor. If the split is not yet
@@ -129,8 +129,9 @@ class BaseClpCursor {
   clp_s::InputSource inputSource_;
   std::vector<Field> outputColumns_;
   std::string query_;
-  /// Maps column names to constant values for metadata projection.
-  std::map<std::string, MetadataValue> metadataColumnValues_;
+  /// Maps column names to constant values fetched from metadata database for
+  /// metadata projection.
+  std::map<std::string, MetadataValueType> metadataColumnValues_;
   std::string splitPath_;
 
  private:

--- a/velox/connectors/clp/search_lib/BaseClpCursor.h
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.h
@@ -75,17 +75,18 @@ class BaseClpCursor {
         splitPath_(std::string(splitPath)) {}
   virtual ~BaseClpCursor() = default;
 
-  using ColumnValue = std::variant<std::string, int64_t, double>;
+  using MetadataValue = std::variant<std::string, int64_t, double>;
 
   /// Executes a query. This function parses, validates, and prepares the given
   /// query for execution.
   ///
   /// @param query The KQL query to execute.
+  /// @param metadataColumnValues Constant values for metadata columns.
   /// @param outputColumns A vector specifying the columns to be included in the
   /// query result.
   void executeQuery(
       const std::string& query,
-      const std::map<std::string, ColumnValue>& projectionNameValue,
+      const std::map<std::string, MetadataValue>& metadataColumnValues,
       const std::vector<Field>& outputColumns);
 
   /// Fetches the next set of rows from the cursor. If the split is not yet
@@ -128,7 +129,8 @@ class BaseClpCursor {
   clp_s::InputSource inputSource_;
   std::vector<Field> outputColumns_;
   std::string query_;
-  std::map<std::string, ColumnValue> projectionNameValue_;
+  /// Maps column names to constant values for metadata projection.
+  std::map<std::string, MetadataValue> metadataColumnValues_;
   std::string splitPath_;
 
  private:

--- a/velox/connectors/clp/search_lib/BaseClpCursor.h
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.h
@@ -83,6 +83,7 @@ class BaseClpCursor {
   /// query result.
   void executeQuery(
       const std::string& query,
+      const std::map<std::string, std::string>& projectionNameValue,
       const std::vector<Field>& outputColumns);
 
   /// Fetches the next set of rows from the cursor. If the split is not yet
@@ -125,6 +126,7 @@ class BaseClpCursor {
   clp_s::InputSource inputSource_;
   std::vector<Field> outputColumns_;
   std::string query_;
+  std::map<std::string, std::string> projectionNameValue_;
   std::string splitPath_;
 
  private:

--- a/velox/connectors/clp/search_lib/BaseClpCursor.h
+++ b/velox/connectors/clp/search_lib/BaseClpCursor.h
@@ -75,6 +75,8 @@ class BaseClpCursor {
         splitPath_(std::string(splitPath)) {}
   virtual ~BaseClpCursor() = default;
 
+  using ColumnValue = std::variant<std::string, int64_t, double>;
+
   /// Executes a query. This function parses, validates, and prepares the given
   /// query for execution.
   ///
@@ -83,7 +85,7 @@ class BaseClpCursor {
   /// query result.
   void executeQuery(
       const std::string& query,
-      const std::map<std::string, std::string>& projectionNameValue,
+      const std::map<std::string, ColumnValue>& projectionNameValue,
       const std::vector<Field>& outputColumns);
 
   /// Fetches the next set of rows from the cursor. If the split is not yet
@@ -126,7 +128,7 @@ class BaseClpCursor {
   clp_s::InputSource inputSource_;
   std::vector<Field> outputColumns_;
   std::string query_;
-  std::map<std::string, std::string> projectionNameValue_;
+  std::map<std::string, ColumnValue> projectionNameValue_;
   std::string splitPath_;
 
  private:

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -72,7 +72,7 @@ VectorPtr ClpIrCursor::createVector(
 ErrorCode ClpIrCursor::loadSplit() {
   auto networkAuthOption = inputSource_ == InputSource::Filesystem
       ? NetworkAuthOption{.method = AuthMethod::None}
-  : NetworkAuthOption{.method = AuthMethod::S3PresignedUrlV4};
+      : NetworkAuthOption{.method = AuthMethod::S3PresignedUrlV4};
 
   auto projections = splitFieldsToNamesAndTypes();
   auto queryHandlerResult{QueryHandlerType::create(
@@ -165,8 +165,8 @@ ClpIrCursor::splitFieldsToNamesAndTypes() {
 ystdlib::error_handling::Result<void> ClpIrCursor::deserialize(
     uint64_t numRows) {
   filteredLogEvents_->clear();
-  uint64_t cnt{0};
-  while (cnt < numRows) {
+  uint64_t num_log_events{0};
+  while (num_log_events < numRows) {
     auto deserializeResult =
         irDeserializer_->deserialize_next_ir_unit(*irReaderZstdWrapper_);
     if (deserializeResult.has_error()) {
@@ -174,15 +174,40 @@ ystdlib::error_handling::Result<void> ClpIrCursor::deserialize(
       if (std::errc::result_out_of_range == error ||
           irDeserializer_->is_stream_completed()) {
         break;
-          }
+      }
       return error;
     }
     if (::clp::ffi::ir_stream::IrUnitType::LogEvent ==
         deserializeResult.value()) {
-      ++cnt;
-        }
+      ++num_log_events;
+    }
   }
   return ystdlib::error_handling::success();
+}
+
+VectorPtr ClpIrCursor::createMetadataProjectionVector(
+    const Field& projectedColumn,
+    const TypePtr& vectorType,
+    size_t vectorSize,
+    memory::MemoryPool* pool) {
+  auto metadata_it = metadataColumnValues_.find(projectedColumn.name);
+  if (metadata_it == metadataColumnValues_.end()) {
+    return nullptr;
+  }
+
+  const MetadataValue& metadata_value = metadata_it->second;
+
+  // Create constant vector from the metadata value.
+  auto vector = std::visit(
+      [&](auto&& value) -> VectorPtr {
+        return BaseVector::createConstant(
+            vectorType, velox::variant(value), vectorSize, pool);
+      },
+      metadata_value);
+
+  ++projectedColumnIndex_;
+  ++columnIndex_;
+  return vector;
 }
 
 VectorPtr ClpIrCursor::createVectorHelper(
@@ -218,50 +243,18 @@ VectorPtr ClpIrCursor::createVectorHelper(
       "Projected column index out of bounds");
   auto projectedColumn = outputColumns_[columnIndex_];
   auto projectedColumnType = projectedColumn.type;
-  auto it = projectedColumnIdxNodeIdsMap_.find(projectedColumnIndex_);
+  auto projection_it = projectedColumnIdxNodeIdsMap_.find(projectedColumnIndex_);
   std::vector<::clp::ffi::SchemaTree::Node::id_t> projectedColumnNodeIds{};
   bool isResolved =
-      it != projectedColumnIdxNodeIdsMap_.end() && !it->second.empty();
+      projection_it != projectedColumnIdxNodeIdsMap_.end() && !projection_it->second.empty();
   if (isResolved) {
-    projectedColumnNodeIds = it->second;
+    projectedColumnNodeIds = projection_it->second;
   } else {
-    // Handle metadata projection with std::variant
-    auto iterMetadata = projectionNameValue_.find(projectedColumn.name);
-    if (iterMetadata != projectionNameValue_.end()) {
-      const ColumnValue& columnValue = iterMetadata->second;
-
-      // Create constant vector based on the variant type
-      vector = std::visit([&](auto&& value) -> VectorPtr {
-        using T = std::decay_t<decltype(value)>;
-
-        if constexpr (std::is_same_v<T, std::string>) {
-          // String type
-          return BaseVector::createConstant(
-              vectorType,
-              velox::variant(value),
-              vectorSize,
-              pool);
-        } else if constexpr (std::is_same_v<T, int64_t>) {
-          // Integer type
-          return BaseVector::createConstant(
-              vectorType,
-              velox::variant(value),
-              vectorSize,
-              pool);
-        } else if constexpr (std::is_same_v<T, double>) {
-          // Double type
-          return BaseVector::createConstant(
-              vectorType,
-              velox::variant(value),
-              vectorSize,
-              pool);
-        }
-      }, columnValue);
-
-      // We can just return this directly; no need for LazyVector.
-      ++projectedColumnIndex_;
-      ++columnIndex_;
-      return vector;
+    // Try creating a constant vector from metadata projection.
+    auto metadata_vector = createMetadataProjectionVector(
+        projectedColumn, vectorType, vectorSize, pool);
+    if (metadata_vector != nullptr) {
+      return metadata_vector;
     }
   }
 
@@ -280,4 +273,4 @@ VectorPtr ClpIrCursor::createVectorHelper(
       std::move(vector));
 }
 
-}// namespace facebook::velox::connector::clp::search_lib
+} // namespace facebook::velox::connector::clp::search_lib

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -26,7 +26,6 @@
 using namespace clp_s;
 
 namespace facebook::velox::connector::clp::search_lib {
-
 uint64_t ClpIrCursor::fetchNext(uint64_t numRows) {
   columnIndex_ = 0;
   projectedColumnIndex_ = 0;
@@ -73,7 +72,7 @@ VectorPtr ClpIrCursor::createVector(
 ErrorCode ClpIrCursor::loadSplit() {
   auto networkAuthOption = inputSource_ == InputSource::Filesystem
       ? NetworkAuthOption{.method = AuthMethod::None}
-      : NetworkAuthOption{.method = AuthMethod::S3PresignedUrlV4};
+  : NetworkAuthOption{.method = AuthMethod::S3PresignedUrlV4};
 
   auto projections = splitFieldsToNamesAndTypes();
   auto queryHandlerResult{QueryHandlerType::create(
@@ -175,13 +174,13 @@ ystdlib::error_handling::Result<void> ClpIrCursor::deserialize(
       if (std::errc::result_out_of_range == error ||
           irDeserializer_->is_stream_completed()) {
         break;
-      }
+          }
       return error;
     }
     if (::clp::ffi::ir_stream::IrUnitType::LogEvent ==
         deserializeResult.value()) {
       ++cnt;
-    }
+        }
   }
   return ystdlib::error_handling::success();
 }
@@ -226,26 +225,46 @@ VectorPtr ClpIrCursor::createVectorHelper(
   if (isResolved) {
     projectedColumnNodeIds = it->second;
   } else {
-    // this is where we handle metadata projection
-    auto iterMetadata = this->projectionNameValue_.find(projectedColumn.name);
-    if (iterMetadata != this->projectionNameValue_.end()) {
-      // iterMetadata->second is your constant value (e.g. std::string)
-      const auto& value = iterMetadata->second;
+    // Handle metadata projection with std::variant
+    auto iterMetadata = projectionNameValue_.find(projectedColumn.name);
+    if (iterMetadata != projectionNameValue_.end()) {
+      const ColumnValue& columnValue = iterMetadata->second;
 
-      // Constant vector of size `vectorSize` where every row == value
-      vector = BaseVector::createConstant(
-          vectorType,          // TypePtr
-          velox::variant(value),        // scalar value
-          vectorSize,                   // number of rows
-          pool);                        // MemoryPool*
+      // Create constant vector based on the variant type
+      vector = std::visit([&](auto&& value) -> VectorPtr {
+        using T = std::decay_t<decltype(value)>;
+
+        if constexpr (std::is_same_v<T, std::string>) {
+          // String type
+          return BaseVector::createConstant(
+              vectorType,
+              velox::variant(value),
+              vectorSize,
+              pool);
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+          // Integer type
+          return BaseVector::createConstant(
+              vectorType,
+              velox::variant(value),
+              vectorSize,
+              pool);
+        } else if constexpr (std::is_same_v<T, double>) {
+          // Double type
+          return BaseVector::createConstant(
+              vectorType,
+              velox::variant(value),
+              vectorSize,
+              pool);
+        }
+      }, columnValue);
 
       // We can just return this directly; no need for LazyVector.
       ++projectedColumnIndex_;
       ++columnIndex_;
       return vector;
     }
-
   }
+
   projectedColumnIndex_++;
   columnIndex_++;
   return std::make_shared<LazyVector>(
@@ -261,4 +280,4 @@ VectorPtr ClpIrCursor::createVectorHelper(
       std::move(vector));
 }
 
-} // namespace facebook::velox::connector::clp::search_lib
+}// namespace facebook::velox::connector::clp::search_lib

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -225,6 +225,26 @@ VectorPtr ClpIrCursor::createVectorHelper(
       it != projectedColumnIdxNodeIdsMap_.end() && !it->second.empty();
   if (isResolved) {
     projectedColumnNodeIds = it->second;
+  } else {
+    // this is where we handle metadata projection
+    auto iterMetadata = this->projectionNameValue_.find(projectedColumn.name);
+    if (iterMetadata != this->projectionNameValue_.end()) {
+      // iterMetadata->second is your constant value (e.g. std::string)
+      const auto& value = iterMetadata->second;
+
+      // Constant vector of size `vectorSize` where every row == value
+      vector = BaseVector::createConstant(
+          vectorType,          // TypePtr
+          velox::variant(value),        // scalar value
+          vectorSize,                   // number of rows
+          pool);                        // MemoryPool*
+
+      // We can just return this directly; no need for LazyVector.
+      ++projectedColumnIndex_;
+      ++columnIndex_;
+      return vector;
+    }
+
   }
   projectedColumnIndex_++;
   columnIndex_++;

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -165,8 +165,8 @@ ClpIrCursor::splitFieldsToNamesAndTypes() {
 ystdlib::error_handling::Result<void> ClpIrCursor::deserialize(
     uint64_t numRows) {
   filteredLogEvents_->clear();
-  uint64_t num_log_events{0};
-  while (num_log_events < numRows) {
+  uint64_t cnt{0};
+  while (cnt < numRows) {
     auto deserializeResult =
         irDeserializer_->deserialize_next_ir_unit(*irReaderZstdWrapper_);
     if (deserializeResult.has_error()) {
@@ -179,7 +179,7 @@ ystdlib::error_handling::Result<void> ClpIrCursor::deserialize(
     }
     if (::clp::ffi::ir_stream::IrUnitType::LogEvent ==
         deserializeResult.value()) {
-      ++num_log_events;
+      ++cnt;
     }
   }
   return ystdlib::error_handling::success();
@@ -195,7 +195,7 @@ VectorPtr ClpIrCursor::createMetadataProjectionVector(
     return nullptr;
   }
 
-  const MetadataValue& metadata_value = metadata_it->second;
+  const MetadataValueType& metadata_value = metadata_it->second;
 
   // Create constant vector from the metadata value.
   auto vector = std::visit(
@@ -248,15 +248,16 @@ VectorPtr ClpIrCursor::createVectorHelper(
   std::vector<::clp::ffi::SchemaTree::Node::id_t> projectedColumnNodeIds{};
   bool isResolved = projection_it != projectedColumnIdxNodeIdsMap_.end() &&
       !projection_it->second.empty();
+  /// IMPORTANT: When a column name exists in both metadata and data sources,
+  /// the metadata column value takes precedence.
+  auto metadata_vector = createMetadataProjectionVector(
+      projectedColumn, vectorType, vectorSize, pool);
+  if (metadata_vector != nullptr) {
+    return metadata_vector;
+  }
+
   if (isResolved) {
     projectedColumnNodeIds = projection_it->second;
-  } else {
-    // Try creating a constant vector from metadata projection.
-    auto metadata_vector = createMetadataProjectionVector(
-        projectedColumn, vectorType, vectorSize, pool);
-    if (metadata_vector != nullptr) {
-      return metadata_vector;
-    }
   }
 
   projectedColumnIndex_++;

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.cpp
@@ -243,10 +243,11 @@ VectorPtr ClpIrCursor::createVectorHelper(
       "Projected column index out of bounds");
   auto projectedColumn = outputColumns_[columnIndex_];
   auto projectedColumnType = projectedColumn.type;
-  auto projection_it = projectedColumnIdxNodeIdsMap_.find(projectedColumnIndex_);
+  auto projection_it =
+      projectedColumnIdxNodeIdsMap_.find(projectedColumnIndex_);
   std::vector<::clp::ffi::SchemaTree::Node::id_t> projectedColumnNodeIds{};
-  bool isResolved =
-      projection_it != projectedColumnIdxNodeIdsMap_.end() && !projection_it->second.empty();
+  bool isResolved = projection_it != projectedColumnIdxNodeIdsMap_.end() &&
+      !projection_it->second.empty();
   if (isResolved) {
     projectedColumnNodeIds = projection_it->second;
   } else {

--- a/velox/connectors/clp/search_lib/ir/ClpIrCursor.h
+++ b/velox/connectors/clp/search_lib/ir/ClpIrCursor.h
@@ -101,6 +101,21 @@ class ClpIrCursor final : public BaseClpCursor {
       memory::MemoryPool* pool,
       const TypePtr& vectorType,
       size_t vectorSize);
+
+  /**
+   * Creates a constant vector for metadata projection if the column is found.
+   * @param projectedColumn The column to create a vector for.
+   * @param vectorType The type of vector to create.
+   * @param vectorSize Number of rows in the vector.
+   * @param pool Memory pool for vector allocation.
+   * @return A constant vector filled with the metadata value.
+   * @return nullptr if the column is not in metadataColumnValues_.
+   */
+  VectorPtr createMetadataProjectionVector(
+      const Field& projectedColumn,
+      const TypePtr& vectorType,
+      size_t vectorSize,
+      memory::MemoryPool* pool);
 };
 
 } // namespace facebook::velox::connector::clp::search_lib

--- a/velox/connectors/clp/tests/CMakeLists.txt
+++ b/velox/connectors/clp/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_executable(velox_clp_connector_test ClpConfigTest.cpp ClpConnectorTest.cpp
-               ClpMetadataProjectionTest.cpp)
+                                        ClpMetadataProjectionTest.cpp)
 
 add_test(velox_clp_connector_test velox_clp_connector_test)
 

--- a/velox/connectors/clp/tests/CMakeLists.txt
+++ b/velox/connectors/clp/tests/CMakeLists.txt
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_clp_connector_test ClpConfigTest.cpp ClpConnectorTest.cpp)
+add_executable(velox_clp_connector_test ClpConfigTest.cpp ClpConnectorTest.cpp
+               ClpMetadataProjectionTest.cpp)
 
 add_test(velox_clp_connector_test velox_clp_connector_test)
 

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -68,8 +68,15 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
       const std::string& splitPath,
       ClpConnectorSplit::SplitType type,
       std::shared_ptr<std::string> kqlQuery) {
+    auto emptyMetadataMap =
+      std::make_shared<std::map<std::string, MetadataValue>>();
     return exec::Split(std::make_shared<ClpConnectorSplit>(
-        kClpConnectorId, splitPath, static_cast<int>(type), kqlQuery));
+        kClpConnectorId,
+        splitPath,
+        static_cast<int>(type),
+        kqlQuery,
+        emptyMetadataMap
+      ));
   }
 
   RowVectorPtr getResults(

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -69,14 +69,30 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
       ClpConnectorSplit::SplitType type,
       std::shared_ptr<std::string> kqlQuery) {
     auto emptyMetadataMap =
-      std::make_shared<std::map<std::string, MetadataValue>>();
+        std::make_shared<std::map<std::string, MetadataValue>>();
     return exec::Split(std::make_shared<ClpConnectorSplit>(
         kClpConnectorId,
         splitPath,
         static_cast<int>(type),
         kqlQuery,
-        emptyMetadataMap
-      ));
+        emptyMetadataMap));
+  }
+
+  /// Creates a CLP split with metadata column values for testing metadata
+  /// projection.
+  exec::Split makeClpSplitWithMetadata(
+      const std::string& splitPath,
+      ClpConnectorSplit::SplitType type,
+      std::shared_ptr<std::string> kqlQuery,
+      std::map<std::string, MetadataValue> metadataValues) {
+    auto metadataMap = std::make_shared<std::map<std::string, MetadataValue>>(
+        std::move(metadataValues));
+    return exec::Split(std::make_shared<ClpConnectorSplit>(
+        kClpConnectorId,
+        splitPath,
+        static_cast<int>(type),
+        kqlQuery,
+        metadataMap));
   }
 
   RowVectorPtr getResults(
@@ -958,6 +974,100 @@ TEST_F(ClpConnectorTest, test5HybridPushdown) {
                                      Timestamp(1746003205, 0),
                                  }),
                                  makeFlatVector<double>({1, 1, 1, 1, 1, 1})});
+  test::assertEqualVectors(expected, output);
+}
+
+/**
+ * Tests metadata projection by injecting constant values for columns that are
+ * pre-fetched from the metadata database. This test validates that:
+ * 1. String metadata values are correctly projected as constant vectors
+ * 2. Integer metadata values are correctly projected as constant vectors
+ * 3. Double metadata values are correctly projected as constant vectors
+ * 4. Metadata projection works with IR split type
+ * 5. Metadata columns are combined correctly with regular data columns
+ */
+TEST_F(ClpConnectorTest, metadataProjection) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
+
+  // Define metadata values of different types
+  std::map<std::string, MetadataValue> metadataValues = {
+      {"source_file", std::string("/var/log/app.log")},
+      {"partition_id", static_cast<int64_t>(42)},
+      {"sampling_rate", 0.75}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(ROW(
+                      {"requestId",
+                       "method",
+                       "source_file",
+                       "partition_id",
+                       "sampling_rate"},
+                      {VARCHAR(), VARCHAR(), VARCHAR(), BIGINT(), DOUBLE()}))
+                  .tableHandle(std::make_shared<ClpTableHandle>(
+                      kClpConnectorId, "test_1"))
+                  .assignments(
+                      {{"requestId",
+                        std::make_shared<ClpColumnHandle>(
+                            "requestId", "requestId", VARCHAR())},
+                       {"method",
+                        std::make_shared<ClpColumnHandle>(
+                            "method", "method", VARCHAR())},
+                       {"source_file",
+                        std::make_shared<ClpColumnHandle>(
+                            "source_file", "source_file", VARCHAR())},
+                       {"partition_id",
+                        std::make_shared<ClpColumnHandle>(
+                            "partition_id", "partition_id", BIGINT())},
+                       {"sampling_rate",
+                        std::make_shared<ClpColumnHandle>(
+                            "sampling_rate", "sampling_rate", DOUBLE())}})
+                  .endTableScan()
+                  .planNode();
+
+  auto output = getResults(
+      plan,
+      {makeClpSplitWithMetadata(
+          getExampleFilePath("test_1_ir.clp.zst"),
+          ClpConnectorSplit::SplitType::kIr,
+          kqlQuery,
+          metadataValues)});
+
+  auto expected = makeRowVector(
+      {// requestId (from data)
+       makeFlatVector<StringView>({
+           "req-100",
+           "req-101",
+           "req-102",
+           "req-103",
+           "req-104",
+           "req-105",
+           "req-106",
+           "req-107",
+           "req-108",
+           "req-109",
+       }),
+       // method (from data)
+       makeFlatVector<StringView>({
+           "GET",
+           "POST",
+           "GET",
+           "PUT",
+           "DELETE",
+           "GET",
+           "POST",
+           "GET",
+           "PATCH",
+           "GET",
+       }),
+       // source_file (metadata - string constant)
+       makeFlatVector<StringView>(
+           10, [](auto /* row */) { return "/var/log/app.log"; }),
+       // partition_id (metadata - int64 constant)
+       makeFlatVector<int64_t>(10, [](auto /* row */) { return 42; }),
+       // sampling_rate (metadata - double constant)
+       makeFlatVector<double>(10, [](auto /* row */) { return 0.75; })});
+
   test::assertEqualVectors(expected, output);
 }
 

--- a/velox/connectors/clp/tests/ClpConnectorTest.cpp
+++ b/velox/connectors/clp/tests/ClpConnectorTest.cpp
@@ -69,30 +69,13 @@ class ClpConnectorTest : public exec::test::OperatorTestBase {
       ClpConnectorSplit::SplitType type,
       std::shared_ptr<std::string> kqlQuery) {
     auto emptyMetadataMap =
-        std::make_shared<std::map<std::string, MetadataValue>>();
+        std::make_shared<std::map<std::string, MetadataValueType>>();
     return exec::Split(std::make_shared<ClpConnectorSplit>(
         kClpConnectorId,
         splitPath,
         static_cast<int>(type),
         kqlQuery,
         emptyMetadataMap));
-  }
-
-  /// Creates a CLP split with metadata column values for testing metadata
-  /// projection.
-  exec::Split makeClpSplitWithMetadata(
-      const std::string& splitPath,
-      ClpConnectorSplit::SplitType type,
-      std::shared_ptr<std::string> kqlQuery,
-      std::map<std::string, MetadataValue> metadataValues) {
-    auto metadataMap = std::make_shared<std::map<std::string, MetadataValue>>(
-        std::move(metadataValues));
-    return exec::Split(std::make_shared<ClpConnectorSplit>(
-        kClpConnectorId,
-        splitPath,
-        static_cast<int>(type),
-        kqlQuery,
-        metadataMap));
   }
 
   RowVectorPtr getResults(
@@ -974,100 +957,6 @@ TEST_F(ClpConnectorTest, test5HybridPushdown) {
                                      Timestamp(1746003205, 0),
                                  }),
                                  makeFlatVector<double>({1, 1, 1, 1, 1, 1})});
-  test::assertEqualVectors(expected, output);
-}
-
-/**
- * Tests metadata projection by injecting constant values for columns that are
- * pre-fetched from the metadata database. This test validates that:
- * 1. String metadata values are correctly projected as constant vectors
- * 2. Integer metadata values are correctly projected as constant vectors
- * 3. Double metadata values are correctly projected as constant vectors
- * 4. Metadata projection works with IR split type
- * 5. Metadata columns are combined correctly with regular data columns
- */
-TEST_F(ClpConnectorTest, metadataProjection) {
-  const std::shared_ptr<std::string> kqlQuery = nullptr;
-
-  // Define metadata values of different types
-  std::map<std::string, MetadataValue> metadataValues = {
-      {"source_file", std::string("/var/log/app.log")},
-      {"partition_id", static_cast<int64_t>(42)},
-      {"sampling_rate", 0.75}};
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .outputType(ROW(
-                      {"requestId",
-                       "method",
-                       "source_file",
-                       "partition_id",
-                       "sampling_rate"},
-                      {VARCHAR(), VARCHAR(), VARCHAR(), BIGINT(), DOUBLE()}))
-                  .tableHandle(std::make_shared<ClpTableHandle>(
-                      kClpConnectorId, "test_1"))
-                  .assignments(
-                      {{"requestId",
-                        std::make_shared<ClpColumnHandle>(
-                            "requestId", "requestId", VARCHAR())},
-                       {"method",
-                        std::make_shared<ClpColumnHandle>(
-                            "method", "method", VARCHAR())},
-                       {"source_file",
-                        std::make_shared<ClpColumnHandle>(
-                            "source_file", "source_file", VARCHAR())},
-                       {"partition_id",
-                        std::make_shared<ClpColumnHandle>(
-                            "partition_id", "partition_id", BIGINT())},
-                       {"sampling_rate",
-                        std::make_shared<ClpColumnHandle>(
-                            "sampling_rate", "sampling_rate", DOUBLE())}})
-                  .endTableScan()
-                  .planNode();
-
-  auto output = getResults(
-      plan,
-      {makeClpSplitWithMetadata(
-          getExampleFilePath("test_1_ir.clp.zst"),
-          ClpConnectorSplit::SplitType::kIr,
-          kqlQuery,
-          metadataValues)});
-
-  auto expected = makeRowVector(
-      {// requestId (from data)
-       makeFlatVector<StringView>({
-           "req-100",
-           "req-101",
-           "req-102",
-           "req-103",
-           "req-104",
-           "req-105",
-           "req-106",
-           "req-107",
-           "req-108",
-           "req-109",
-       }),
-       // method (from data)
-       makeFlatVector<StringView>({
-           "GET",
-           "POST",
-           "GET",
-           "PUT",
-           "DELETE",
-           "GET",
-           "POST",
-           "GET",
-           "PATCH",
-           "GET",
-       }),
-       // source_file (metadata - string constant)
-       makeFlatVector<StringView>(
-           10, [](auto /* row */) { return "/var/log/app.log"; }),
-       // partition_id (metadata - int64 constant)
-       makeFlatVector<int64_t>(10, [](auto /* row */) { return 42; }),
-       // sampling_rate (metadata - double constant)
-       makeFlatVector<double>(10, [](auto /* row */) { return 0.75; })});
-
   test::assertEqualVectors(expected, output);
 }
 

--- a/velox/connectors/clp/tests/ClpMetadataProjectionTest.cpp
+++ b/velox/connectors/clp/tests/ClpMetadataProjectionTest.cpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Fs.h"
+#include "velox/connectors/clp/ClpColumnHandle.h"
+#include "velox/connectors/clp/ClpConnector.h"
+#include "velox/connectors/clp/ClpConnectorSplit.h"
+#include "velox/connectors/clp/ClpTableHandle.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace {
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::clp;
+using facebook::velox::exec::test::PlanBuilder;
+
+class ClpMetadataProjectionTest : public exec::test::OperatorTestBase {
+ public:
+  const std::string kClpConnectorId = "test-clp";
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::clp::ClpConnectorFactory>());
+    auto clpConnector =
+        connector::getConnectorFactory(
+            connector::clp::ClpConnectorFactory::kClpConnectorName)
+            ->newConnector(
+                kClpConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>{}));
+    connector::registerConnector(clpConnector);
+  }
+
+  void TearDown() override {
+    connector::unregisterConnector(kClpConnectorId);
+    connector::unregisterConnectorFactory(
+        connector::clp::ClpConnectorFactory::kClpConnectorName);
+    OperatorTestBase::TearDown();
+  }
+
+  /// Creates a CLP split with metadata column values for testing metadata
+  /// projection.
+  exec::Split makeClpSplitWithMetadata(
+      const std::string& splitPath,
+      ClpConnectorSplit::SplitType type,
+      std::shared_ptr<std::string> kqlQuery,
+      std::map<std::string, MetadataValueType> metadataValues) {
+    auto metadataMap =
+        std::make_shared<std::map<std::string, MetadataValueType>>(
+            std::move(metadataValues));
+    return exec::Split(std::make_shared<ClpConnectorSplit>(
+        kClpConnectorId,
+        splitPath,
+        static_cast<int>(type),
+        kqlQuery,
+        metadataMap));
+  }
+
+  RowVectorPtr getResults(
+      const core::PlanNodePtr& planNode,
+      std::vector<exec::Split>&& splits) {
+    return exec::test::AssertQueryBuilder(planNode)
+        .splits(std::move(splits))
+        .copyResults(pool());
+  }
+
+  static std::string getExampleFilePath(const std::string& filePath) {
+    std::string current_path = fs::current_path().string();
+    return current_path + "/examples/" + filePath;
+  }
+};
+
+/**
+ * Tests metadata projection by injecting constant values for columns that are
+ * pre-fetched from the metadata database. This test validates that:
+ * 1. String metadata values are correctly projected as constant vectors
+ * 2. Integer metadata values are correctly projected as constant vectors
+ * 3. Double metadata values are correctly projected as constant vectors
+ * 4. Metadata projection works with IR split type
+ * 5. Metadata columns are combined correctly with regular data columns
+ */
+TEST_F(ClpMetadataProjectionTest, metadataProjection) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
+
+  // Define metadata values of different types
+  std::map<std::string, MetadataValueType> metadataValues = {
+      {"source_file", std::string("/var/log/app.log")},
+      {"partition_id", static_cast<int64_t>(42)},
+      {"sampling_rate", 0.75}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(ROW(
+                      {"requestId",
+                       "method",
+                       "source_file",
+                       "partition_id",
+                       "sampling_rate"},
+                      {VARCHAR(), VARCHAR(), VARCHAR(), BIGINT(), DOUBLE()}))
+                  .tableHandle(std::make_shared<ClpTableHandle>(
+                      kClpConnectorId, "test_1"))
+                  .assignments(
+                      {{"requestId",
+                        std::make_shared<ClpColumnHandle>(
+                            "requestId", "requestId", VARCHAR())},
+                       {"method",
+                        std::make_shared<ClpColumnHandle>(
+                            "method", "method", VARCHAR())},
+                       {"source_file",
+                        std::make_shared<ClpColumnHandle>(
+                            "source_file", "source_file", VARCHAR())},
+                       {"partition_id",
+                        std::make_shared<ClpColumnHandle>(
+                            "partition_id", "partition_id", BIGINT())},
+                       {"sampling_rate",
+                        std::make_shared<ClpColumnHandle>(
+                            "sampling_rate", "sampling_rate", DOUBLE())}})
+                  .endTableScan()
+                  .planNode();
+
+  auto output = getResults(
+      plan,
+      {makeClpSplitWithMetadata(
+          getExampleFilePath("test_1_ir.clp.zst"),
+          ClpConnectorSplit::SplitType::kIr,
+          kqlQuery,
+          metadataValues)});
+
+  auto expected = makeRowVector(
+      {// requestId (from data)
+       makeFlatVector<StringView>({
+           "req-100",
+           "req-101",
+           "req-102",
+           "req-103",
+           "req-104",
+           "req-105",
+           "req-106",
+           "req-107",
+           "req-108",
+           "req-109",
+       }),
+       // method (from data)
+       makeFlatVector<StringView>({
+           "GET",
+           "POST",
+           "GET",
+           "PUT",
+           "DELETE",
+           "GET",
+           "POST",
+           "GET",
+           "PATCH",
+           "GET",
+       }),
+       // source_file (metadata - string constant)
+       makeFlatVector<StringView>(
+           10, [](auto /* row */) { return "/var/log/app.log"; }),
+       // partition_id (metadata - int64 constant)
+       makeFlatVector<int64_t>(10, [](auto /* row */) { return 42; }),
+       // sampling_rate (metadata - double constant)
+       makeFlatVector<double>(10, [](auto /* row */) { return 0.75; })});
+
+  test::assertEqualVectors(expected, output);
+}
+
+/**
+ * Tests that metadata columns take precedence over data columns when a column
+ * name exists in both sources.
+ */
+TEST_F(ClpMetadataProjectionTest, metadataProjectionPrecedence) {
+  const std::shared_ptr<std::string> kqlQuery = nullptr;
+
+  // Define metadata value for "method" column which also exists in the data.
+  // In the data, method has values like "GET", "POST", "PUT", etc.
+  // We override it with a constant metadata value.
+  std::map<std::string, MetadataValueType> metadataValues = {
+      {"method", std::string("METADATA_OVERRIDE")}};
+
+  auto plan =
+      PlanBuilder()
+          .startTableScan()
+          .outputType(ROW({"requestId", "method"}, {VARCHAR(), VARCHAR()}))
+          .tableHandle(
+              std::make_shared<ClpTableHandle>(kClpConnectorId, "test_1"))
+          .assignments(
+              {{"requestId",
+                std::make_shared<ClpColumnHandle>(
+                    "requestId", "requestId", VARCHAR())},
+               {"method",
+                std::make_shared<ClpColumnHandle>(
+                    "method", "method", VARCHAR())}})
+          .endTableScan()
+          .planNode();
+
+  auto output = getResults(
+      plan,
+      {makeClpSplitWithMetadata(
+          getExampleFilePath("test_1_ir.clp.zst"),
+          ClpConnectorSplit::SplitType::kIr,
+          kqlQuery,
+          metadataValues)});
+
+  // Expected: method column should have the metadata value "METADATA_OVERRIDE"
+  // for all rows, NOT the actual data values ("GET", "POST", etc.)
+  auto expected =
+      makeRowVector({// requestId (from data)
+                     makeFlatVector<StringView>({
+                         "req-100",
+                         "req-101",
+                         "req-102",
+                         "req-103",
+                         "req-104",
+                         "req-105",
+                         "req-106",
+                         "req-107",
+                         "req-108",
+                         "req-109",
+                     }),
+                     // method (from metadata - overrides data values)
+                     makeFlatVector<StringView>(10, [](auto /* row */) {
+                       return "METADATA_OVERRIDE";
+                     })});
+
+  test::assertEqualVectors(expected, output);
+}
+
+} // namespace


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds metadata projection support on the Velox side.

Some projected columns are tracked in a metadata database (e.g., split path, timestamp). During query execution, these metadata values are extracted from the metadata database and passed to Velox workers along with split information. Since these column values are uniform within a split (all rows share the same value), they are injected directly as constant vectors using the pre-fetched metadata values.

Two important notes:
- Projected columns may or may not exist in the data source. For example, split path exists only in the metadata database, while timestamp exists in both the metadata database and data source.
- We currently assume all metadata column values are uniform within a split, which holds true for IR-only files. This assumption will not hold when we support hybrid mode with both Archive and IR files.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

We manually submit below queries to test the end-to-end result of the implemented code:
- All unit tests 
- Basic Functionality
  -  Data column only projection: `SELECT timestamp FROM clp.DEFAULT.cockroachdb_ir LIMIT  100;` 
  -  Metadata and data column projection with different type:  `SELECT timestamp,  tpath, num_messages FROM clp.DEFAULT.cockroachdb_ir LIMIT  100;`  where `tpath` is a `VARCHAR` metadata, and `num_messages` is a `BIGINT` metadata
  -  Metadata column with name mapping projection: `SELECT host_name FROM clp.DEFAULT.cockroachdb_ir LIMIT  100;`  where `host_name` is an exposed name of a `VARCHAR` typed metadata column `hostname`
  -  Metadata column with rangemapping projection: `SELECT ts FROM clp.DEFAULT.cockroachdb_ir LIMIT  100;`  where `ts` is a ranged mapped metadata column: mapping `ts` to `creationtime` and `lastmodifiedtime`
- Metadata projection integration with other features:
  -  With split pruning: `SELECT zone FROM clp.DEFAULT.cockroachdb_ir WHERE host_name = 'host4' LIMIT  100;`  & `SELECT tpath, timestamp  FROM clp.DEFAULT.cockroachdb_ir WHERE num_messages > 100 LIMIT  100;` 
  - With push down:  `SELECT tpath, timestamp  FROM clp.DEFAULT.cockroachdb_ir WHERE severity = 'INFO' LIMIT  100;` 
  - With UDF:  `SELECT tpath,  CLP_GET_JSON_STRING() AS event FROM clp.DEFAULT.cockroachdb_ir WHERE severity = 'INFO' LIMIT  100;` 
 - Metadata projection integration with other features:
    - Non-existing metadata column: SELECT non_exist_metdata_column FROM table
    - Incorrect type metadata column: SELECT wrong_type_metadata_column FROM table


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
