### PR TITLE
chore: Upgrade CLP dependency to v0.8.0.

### DIFF
--- a/CMake/resolve_dependency_modules/clp.cmake
+++ b/CMake/resolve_dependency_modules/clp.cmake
@@ -16,7 +16,7 @@ include_guard(GLOBAL)
 FetchContent_Declare(
   clp
   GIT_REPOSITORY https://github.com/y-scope/clp.git
-  GIT_TAG 9e991ab49681faff0aea259a37b489c3f416e06e)
+  GIT_TAG v0.8.0)
 
 set(CLP_BUILD_CLP_REGEX_UTILS
     OFF

--- a/velox/connectors/clp/search_lib/archive/ClpArchiveCursor.cpp
+++ b/velox/connectors/clp/search_lib/archive/ClpArchiveCursor.cpp
@@ -173,7 +173,7 @@ ErrorCode ClpArchiveCursor::loadSplit() {
         case ColumnType::String:
           columnDescriptor->set_matching_types(
               LiteralType::ClpStringT | LiteralType::VarStringT |
-              LiteralType::EpochDateT);
+              LiteralType::TimestampT);
           break;
         case ColumnType::Integer:
           columnDescriptor->set_matching_types(LiteralType::IntegerT);
@@ -189,7 +189,7 @@ ErrorCode ClpArchiveCursor::loadSplit() {
           break;
         case ColumnType::Timestamp:
           columnDescriptor->set_matching_types(
-              LiteralType::EpochDateT | LiteralType::IntegerT |
+              LiteralType::TimestampT | LiteralType::IntegerT |
               LiteralType::FloatT);
           break;
         default:

--- a/velox/connectors/clp/search_lib/archive/ClpArchiveCursor.cpp
+++ b/velox/connectors/clp/search_lib/archive/ClpArchiveCursor.cpp
@@ -172,8 +172,7 @@ ErrorCode ClpArchiveCursor::loadSplit() {
       switch (column.type) {
         case ColumnType::String:
           columnDescriptor->set_matching_types(
-              LiteralType::ClpStringT | LiteralType::VarStringT |
-              LiteralType::TimestampT);
+              LiteralType::ClpStringT | LiteralType::VarStringT);
           break;
         case ColumnType::Integer:
           columnDescriptor->set_matching_types(LiteralType::IntegerT);

--- a/velox/connectors/clp/search_lib/ir/ClpIrVectorLoader.cpp
+++ b/velox/connectors/clp/search_lib/ir/ClpIrVectorLoader.cpp
@@ -55,18 +55,18 @@ void ClpIrVectorLoader::loadInternal(
         if (value->is<std::string>()) {
           auto stringValue = value->get_immutable_view<std::string>();
           stringVector->set(vectorIndex, StringView(stringValue));
-        } else if (value->is<::clp::ir::EightByteEncodedTextAst>()) {
+        } else if (value->is<::clp::ffi::EightByteEncodedTextAst>()) {
           auto decodeResult =
-              value->get_immutable_view<::clp::ir::EightByteEncodedTextAst>()
-                  .decode_and_unparse();
+              value->get_immutable_view<::clp::ffi::EightByteEncodedTextAst>()
+                  .to_string();
           if (!decodeResult.has_value()) {
             continue;
           }
           stringVector->set(vectorIndex, StringView(decodeResult.value()));
-        } else if (value->is<::clp::ir::FourByteEncodedTextAst>()) {
+        } else if (value->is<::clp::ffi::FourByteEncodedTextAst>()) {
           auto decodeResult =
-              value->get_immutable_view<::clp::ir::FourByteEncodedTextAst>()
-                  .decode_and_unparse();
+              value->get_immutable_view<::clp::ffi::FourByteEncodedTextAst>()
+                  .to_string();
           if (!decodeResult.has_value()) {
             continue;
           }
@@ -117,18 +117,18 @@ void ClpIrVectorLoader::loadInternal(
       case ColumnType::Array: {
         auto arrayVector = std::dynamic_pointer_cast<ArrayVector>(vector);
         std::string jsonString;
-        if (value->is<::clp::ir::EightByteEncodedTextAst>()) {
+        if (value->is<::clp::ffi::EightByteEncodedTextAst>()) {
           auto decodeResult =
-              value->get_immutable_view<::clp::ir::EightByteEncodedTextAst>()
-                  .decode_and_unparse();
+              value->get_immutable_view<::clp::ffi::EightByteEncodedTextAst>()
+                  .to_string();
           if (!decodeResult.has_value()) {
             continue;
           }
           jsonString = std::move(decodeResult.value());
         } else {
           auto decodeResult =
-              value->get_immutable_view<::clp::ir::FourByteEncodedTextAst>()
-                  .decode_and_unparse();
+              value->get_immutable_view<::clp::ffi::FourByteEncodedTextAst>()
+                  .to_string();
           if (!decodeResult.has_value()) {
             continue;
           }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

  - Upgrades CLP dependency from commit `9e991ab` to official release `v0.8.0`
    - This would help us enable S3 support in velox
  - Updates code to adapt to CLP v0.8.0 API changes


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- All unit tests passed.

- End to end test 
  -  Query: `SELECT CLP_GET_JSON_STRING() from clp.default.default limit 100`
  -  Set up: official clp package v0.8.0, OSS version of Presto, velox with changes in this PR, and a locally set minio. 
  - The result is returned as expected.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CLP library dependency to version 0.8.0.

* **Improvements**
  * Refined string and timestamp data type handling in archive search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->